### PR TITLE
Update all references to hep-sf.gitub.io to hsf.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# hep-sf.github.io
+# hsf.github.io
 HEP Software Foundation github site

--- a/github-beginners.md
+++ b/github-beginners.md
@@ -15,7 +15,7 @@ This pages is a GitHub and Git survival kit for people not familiar with these t
 
 At a first glance, GitHub (and Git) may look complex with their "workflows". But they are not so much in fact. What makes these tools great is that they allow a clear separation between your personal work and what you decide to show or export. Your personal work, unlike with tools like SVN, can be versionned and you can work on different things in parallel (branches) very easily.
 
-In the HSF web site context, what is shared is what is in the project repository called, [hep-sf.github.io](https://github.com/HSF/hep-sf.github.io). Your personal environment is made of 2 parts:
+In the HSF web site context, what is shared is what is in the project repository called, [hsf.github.io](https://github.com/HSF/hsf.github.io). Your personal environment is made of 2 parts:
 
 * One personal repository on GitHub, called a *fork*. It is typically created using the GitHub web interface, click on the `Fork` button when you are in the project repository. Despite this is a Git repository, you cannot access it directly from you local computer with Git commands (for example, you cannot `git commit` changes made on your local computer to it).
 * One (or several) clone of your personal repository on GitHub. This is where you'll make/develop your changes, using the full versionning capabilities of Git. And until you publish (`git push`) your changes to your personal repository (fork) on GitHub, they are not visible by anybody else. Once in your personal repository, it is potentially visible but you control when you want to submit these changes to the project repository creating a `pull request`: at this point people can review/comment your changes and people with the appropriate permissions can `merge` your changes in the project repository.
@@ -24,7 +24,7 @@ With this *GitHub workflow*, the only repository you need to have write access t
 
 For simple things, there is an alternative to creating a clone on your local computer: you can use the GitHub editor in the web interface. When you save your changes, this commits your changes and you are asked for *commit message*. Note that this is really limited to situations where your contribution is limited to only one file as you cannot edit several files and commit them togheter this way. Apart from the management of the Git clone, there workflow for pushing your changes to the project repository remains the same, using *pull request*.
 
-Sections below give more details on the main steps involved. Examples are based on the HSF web site [repository](https://github.com/HSF/hep-sf.github.io). Note that there is a help available for each Git command that can be displayed with:
+Sections below give more details on the main steps involved. Examples are based on the HSF web site [repository](https://github.com/HSF/hsf.github.io). Note that there is a help available for each Git command that can be displayed with:
 
 ```bash
 git help
@@ -43,22 +43,22 @@ Once you have an account, if you want to use the full workflow with a clone of t
 
 As explained in the introduction, this involves 2 steps:
 
-* Creating your personal fork: with your browser, open the HSF web site [repository](https://github.com/HSF/hep-sf.github.io) and click on the `Fork` button at the top-right of page.
+* Creating your personal fork: with your browser, open the HSF web site [repository](https://github.com/HSF/hsf.github.io) and click on the `Fork` button at the top-right of page.
 * Creating your local clone of your personal fork (assuming your name is `dupont`: 
 
   ```bash
-  # The local Git repository will be in a directory hep-sf.github.io in your current directory.
+  # The local Git repository will be in a directory hsf.github.io in your current directory.
   # The exact URL to use is on the right side of web page, when you display your personal fork.
-  git clone git@github.com:dupont/hep-sf.github.io.git
+  git clone git@github.com:dupont/hsf.github.io.git
   # Move in your repository
-  cd hep-sf.github.io
+  cd hsf.github.io
   ```
 
 * Connect your local clone to the project repository: as it will be explained in other sections, there are several occasions where you will want to import changes that happened in the project repository into your local clone that you use to develop your contributions. In Git, this involves creating a *remote* and is done with:
 
   ```bash
   # Later to refer to the project repository, we'll use the remote called upstream
-  git remote add upstream git@github.com:HSF/hep-sf.github.io.git
+  git remote add upstream git@github.com:HSF/hsf.github.io.git
   ```
 
 Note that adding a remote adds no information to the repository itself.

--- a/gsoc/guideline.md
+++ b/gsoc/guideline.md
@@ -10,10 +10,10 @@ layout: default
 
  * Option A: email GSoC administrators: [Sergei Gleyzer](mailto:sergei@cern.ch), [Enric Tejedor Saavedra](mailto:etejedor@cern.ch) and [Antoine Perus](mailto:perus@lal.in2p3.fr) 
  * Option B (via git): 
-   * fork [git repository](https://github.com/HSF/hep-sf.github.io) 
+   * fork [git repository](https://github.com/HSF/hsf.github.io) 
    * add `_gsocproposals/YEAR/proposal_YOURPROJECTyourproposal.md` (for example `proposal_ROOTspark.md`)
    * add a front matter as given in this
-   [example](https://raw.githubusercontent.com/hep-sf/hep-sf.github.io/master/_gsocprojects/2018/project_ROOT.md)
+   [example](https://raw.githubusercontent.com/hep-sf/hsf.github.io/master/_gsocprojects/2018/project_ROOT.md)
       * Make sure the `year` attribute is correct for your proposal
    * make a pull request
 
@@ -23,7 +23,7 @@ layout: default
 
 Proposals are attached to aproject (e.g. ROOT, CMS...). If you want to add a project for your proposal, you need to create 
 a MD file describing your project in `_gsocprojects/2018` directory (must start with `project_`,
-look at [ROOT project](https://raw.githubusercontent.com/HSF/hep-sf.github.io/master/_gsocprojects/2018/project_ROOT.md) for an example).
+look at [ROOT project](https://raw.githubusercontent.com/HSF/hsf.github.io/master/_gsocprojects/2018/project_ROOT.md) for an example).
 This is a very simple file, containing only a *front matter* section that defines the attributes of
 your organization. The 2 mandatory attributes are `project` (your project name) and `layout` (which must be `default`).
 In addition you can use 2 optional attributes:
@@ -31,7 +31,7 @@ In addition you can use 2 optional attributes:
 * `title`: the name of the project to use in the page title. By default, `project` attribute is used.
 * `description`: a description of your project that will be added before the list of proposals attached to the project.
 
-It can be several lines: look at the [example](https://raw.githubusercontent.com/hep-sf/hep-sf.github.io/master/_gsocprojects/2018/project_SixTrack.md)
+It can be several lines: look at the [example](https://raw.githubusercontent.com/hep-sf/hsf.github.io/master/_gsocprojects/2018/project_SixTrack.md)
 for detailed syntax. The content is a standard Markdown text idented by at least one space (the number is not important
 but must be the same for all lines).
 
@@ -64,7 +64,7 @@ organization:
 ```
 
 To create a new organization, copy
-[_gsocorgs/2018/cern.md](https://raw.githubusercontent.com/hep-sf/hep-sf.github.io/master/_gsocorgs/2018/cern.md),
+[_gsocorgs/2018/cern.md](https://raw.githubusercontent.com/hep-sf/hsf.github.io/master/_gsocorgs/2018/cern.md),
 create a file for your organization and edit its contents as appropriate.
 
 

--- a/gsoc/guideline.md
+++ b/gsoc/guideline.md
@@ -13,7 +13,7 @@ layout: default
    * fork [git repository](https://github.com/HSF/hsf.github.io) 
    * add `_gsocproposals/YEAR/proposal_YOURPROJECTyourproposal.md` (for example `proposal_ROOTspark.md`)
    * add a front matter as given in this
-   [example](https://raw.githubusercontent.com/hep-sf/hsf.github.io/master/_gsocprojects/2018/project_ROOT.md)
+   [example](https://raw.githubusercontent.com/hsf/hsf.github.io/master/_gsocprojects/2018/project_ROOT.md)
       * Make sure the `year` attribute is correct for your proposal
    * make a pull request
 
@@ -31,7 +31,7 @@ In addition you can use 2 optional attributes:
 * `title`: the name of the project to use in the page title. By default, `project` attribute is used.
 * `description`: a description of your project that will be added before the list of proposals attached to the project.
 
-It can be several lines: look at the [example](https://raw.githubusercontent.com/hep-sf/hsf.github.io/master/_gsocprojects/2018/project_SixTrack.md)
+It can be several lines: look at the [example](https://raw.githubusercontent.com/hsf/hsf.github.io/master/_gsocprojects/2018/project_SixTrack.md)
 for detailed syntax. The content is a standard Markdown text idented by at least one space (the number is not important
 but must be the same for all lines).
 
@@ -64,7 +64,7 @@ organization:
 ```
 
 To create a new organization, copy
-[_gsocorgs/2018/cern.md](https://raw.githubusercontent.com/hep-sf/hsf.github.io/master/_gsocorgs/2018/cern.md),
+[_gsocorgs/2018/cern.md](https://raw.githubusercontent.com/hsf/hsf.github.io/master/_gsocorgs/2018/cern.md),
 create a file for your organization and edit its contents as appropriate.
 
 

--- a/howto-website.md
+++ b/howto-website.md
@@ -19,12 +19,12 @@ A [HSF documentation](/jekyll-beginners.html) provides some useful hints to make
 
 For adding information to this page or improving it, we follow the *[pull request](https://help.github.com/articles/using-pull-requests/)* workflow in GitHub.
 
-Just fork our HSF [website repository](https://github.com/HSF/hep-sf.github.io), edit the
+Just fork our HSF [website repository](https://github.com/HSF/hsf.github.io), edit the
 files you want to edit, push them to your fork, and open a pull request.
 
 If you wish (and it is recommended) you can easily set up a local instance of the newsletter site in order to preview your submissions. See the [documentation](https://help.github.com/articles/using-jekyll-with-pages/)
 on installing and running Jekyll.
-The website uses the master branch of the hep-sf.github.io repository.
+The website uses the master branch of the hsf.github.io repository.
 
 If you are not familiar with GitHub and Git, you can read our [survival kit](/github-beginners.html)!
 

--- a/jekyll-beginners.md
+++ b/jekyll-beginners.md
@@ -115,8 +115,8 @@ but the short story is:
 * If you don't have one yet, create a clone of the GitHub HSF web site repository and move to the directory created (by default `hep-sf.githb.io`):
 
   ```bash
-  git clone https://github.com/HSF/hep-sf.github.io.git
-  cd hep-sf.github.io
+  git clone https://github.com/HSF/hsf.github.io.git
+  cd hsf.github.io
   ```
 
 * Install/update your Jekyll installation (must be done regularly):

--- a/organization/_posts/2015-10-22-startup.md
+++ b/organization/_posts/2015-10-22-startup.md
@@ -59,7 +59,7 @@ all - agreed.
 
 Torre - implemented the last important piece of functionality in the software knowledge base, establishing relations. Working nicely, easy to use. Testing, should have it up on the server in a few days. Then will do a round of adding material and shake out glitches.
 
-Then the top of the todo list will be the newsletter (anyone/everyone free to start putting it together anytime, it's in github, see hep-sf.github.io (url routes to http://news.hepsoftwarefoundation.org/).
+Then the top of the todo list will be the newsletter (anyone/everyone free to start putting it together anytime, it's in github, see hsf.github.io (url routes to http://news.hepsoftwarefoundation.org/).
 
 ## SW projects, development tools/services
 

--- a/organization/_posts/2016-05-19-startup.md
+++ b/organization/_posts/2016-05-19-startup.md
@@ -26,7 +26,7 @@ layout: default
 
 ### Newsletter for LAL workshop
 
--   [*Draft*](https://github.com/HSF/hep-sf.github.io/pull/43/files) from Michel with contributions from Benedikt. One “controversial” issue. It is the second or the third? John: the first one was at CERN. We need to just to agree.
+-   [*Draft*](https://github.com/HSF/hsf.github.io/pull/43/files) from Michel with contributions from Benedikt. One “controversial” issue. It is the second or the third? John: the first one was at CERN. We need to just to agree.
 
 -   One pending issue: what is the role of the software technology forum? Will it cover the performance issues? Change Software Technical Evolution Forum into Software Technology Forum
 
@@ -34,7 +34,7 @@ layout: default
 
 ### Workshop live notes
 
--   [*Draft*](https://github.com/HSF/hep-sf.github.io/pull/40/files) available, produced from final version of the [*GoogleDoc*](https://docs.google.com/document/d/1plPytOtY2HFjSdF3bE6bXJ_aTBQ-OzfbEUcU62X-_qc/edit#) (now readonly)
+-   [*Draft*](https://github.com/HSF/hsf.github.io/pull/40/files) available, produced from final version of the [*GoogleDoc*](https://docs.google.com/document/d/1plPytOtY2HFjSdF3bE6bXJ_aTBQ-OzfbEUcU62X-_qc/edit#) (now readonly)
 
 -   To publish the final notes at the same time as the newsletter. Several modifications went in the GoogleDoc after emails to workshop participants (we do not know the author but several persons told Michel they will review the notes).
 

--- a/organization/_posts/2017-09-21-startup.md
+++ b/organization/_posts/2017-09-21-startup.md
@@ -88,4 +88,4 @@ layout: default
 - Coming out of the CWP it would be good to reinvigorate the packaging group to re-evaluate packaging tool options and encourage some more prototyping.
     
 ## AOB
-- The HTML proofer is having trouble on some URLs. Graeme has been taking a look and has solved some of the problems (from old OpenSSL version or lack of certificates), but some other unexplained failures remain (see [PR#160](https://github.com/HSF/hep-sf.github.io/pull/160)).
+- The HTML proofer is having trouble on some URLs. Graeme has been taking a look and has solved some of the problems (from old OpenSSL version or lack of certificates), but some other unexplained failures remain (see [PR#160](https://github.com/HSF/hsf.github.io/pull/160)).

--- a/organization/_posts/2017-09-28-startup.md
+++ b/organization/_posts/2017-09-28-startup.md
@@ -90,7 +90,7 @@ layout: default
 - Trying to [organise a meeting](http://doodle.com/poll/273b4xf25mquqmn6) for week of 16th October.
     
 ## AOB
-- The website HTML proofer [was fixed](https://github.com/HSF/hep-sf.github.io/pull/162). Please keep your links in good shape.
+- The website HTML proofer [was fixed](https://github.com/HSF/hsf.github.io/pull/162). Please keep your links in good shape.
 - CERN Openlab released its [whitepaper for the next phase](http://openlab.cern/news/press-release-cern-openlab-tackles-ict-challenges-high-luminosity-lhc). Some overlap with the CWP process but done on their own: generally not inconsistent.
 
 

--- a/organization/_posts/2017-10-12-startup.md
+++ b/organization/_posts/2017-10-12-startup.md
@@ -117,4 +117,4 @@ Benedikt reported they would like to start a project for upgrading reconstructio
 - Packaging meeting will be Wednesday 18 October at 1500 CERN time ([agenda](https://indico.cern.ch/event/672745/)) and updates from anyone working on packaging solutions are welcome (contact Graeme to get Indico access).
     
 ## AOB
-- Community calendar contribution guide is a [PR](https://github.com/HSF/hep-sf.github.io/pull/166). We agreed to create a calendar editors Google Group, in addition to having startup team members able to add events.
+- Community calendar contribution guide is a [PR](https://github.com/HSF/hsf.github.io/pull/166). We agreed to create a calendar editors Google Group, in addition to having startup team members able to add events.

--- a/organization/_posts/2018-01-25-startup.md
+++ b/organization/_posts/2018-01-25-startup.md
@@ -22,7 +22,7 @@ layout: default
         developments envisaged run from 2020-2025.
     -   Here we can also add things in addition to what we have on the
         roadmap - could be new and more ambitious/higher risk.
--   Graeme wrote a [short newsletter for the website](https://github.com/HSF/hep-sf.github.io/pull/208) -
+-   Graeme wrote a [short newsletter for the website](https://github.com/HSF/hsf.github.io/pull/208) -
     RFC for the rest of today and try to publish it tomorrow,
     -   Q. Does "sign up for our newsletter" actually mean anything
         beyond sending to hep-sf-forum? A. No - we just broadcast to


### PR DESCRIPTION
Organisation name change requires that the github pages repository also
changes name. See #324.