### PR TITLE
Update website to reflect renaming of Google Groups

### DIFF
--- a/_activities/licensing.md
+++ b/_activities/licensing.md
@@ -24,7 +24,7 @@ In Spring 2015, A working group has been formed with people from the community
 who had already some experiences with licensing issues. This working group, as 
 any in the HSF, is open to new participants and contributions. Most 
 discussions so far took place in the HSF Technical Forum
-(<hep-sf-forum@googlegroups.com>).
+(<hsf-forum@googlegroups.com>).
 
 A first [Technical Note](/notes/HSF-TN-2016-01.pdf) 
 was released in February 2016, 

--- a/_activities/packaging.md
+++ b/_activities/packaging.md
@@ -12,7 +12,7 @@ The group is currently convened by Ben Morgan (Warwick) and Graeme Stewart (CERN
 
 Everyone is welcome to participate and contribute on the forum and to the ongoing meetings:
 
-[Packaging Group Discussion Forum](https://groups.google.com/forum/#!forum/hep-sf-packaging-wg){:target="_hsf_packaging_forum}
+[Packaging Group Discussion Forum](https://groups.google.com/forum/#!forum/hsf-packaging-wg){:target="_hsf_packaging_forum}
 
 [Packaging Group Meetings Indico](https://indico.cern.ch/category/7975/){:target="_hsf_packaging_indico"}
 

--- a/_activities/tracking.md
+++ b/_activities/tracking.md
@@ -18,7 +18,7 @@ experience in and share of software used for track reconstruction. In particular
 We have two mailing lists for exchange of information and technical discussions
 
   * Detector-Technology-Pattern-Recognition@cern.ch (CTD mailing list)
-  * hep-sf-reconstruction@googlegroups.com (HSF mailing list)
+  * hsf-reconstruction@googlegroups.com (HSF mailing list)
 
 ## Meetings
 

--- a/_activities/training.md
+++ b/_activities/training.md
@@ -26,5 +26,5 @@ Other actions in progress include:
 
 ## How to participate ?
 
-Everybody is welcome to join the [forum](https://groups.google.com/forum/#!forum/hep-sf-training-wg) dedicated to HSF training activities. This is the place where ideas and proposals are discussed and actions decided!
+Everybody is welcome to join the [forum](https://groups.google.com/forum/#!forum/hsf-training-wg) dedicated to HSF training activities. This is the place where ideas and proposals are discussed and actions decided!
   

--- a/_includes/about.ext
+++ b/_includes/about.ext
@@ -6,6 +6,6 @@ Informing the community of news across the HSF activity areas. <br>
 <a href="/organization/about.html">Learn more here</a>.
 </p><p>
 For more information on the HEP Software Foundation see the <a href="http://hepsoftwarefoundation.org">HSF website</a> or
-contact the <a href="mailto:hep-sf-startup-team@googlegroups.com">startup team</a>.
+contact the <a href="mailto:hsf-coordination@googlegroups.com">startup team</a>.
     </p>
   </div>

--- a/_includes/sidebar.ext
+++ b/_includes/sidebar.ext
@@ -3,7 +3,7 @@
     <h4>About the HSF</h4>
     <p>
 For more information on the HEP Software Foundation see the <a href="/organization/goals.html">goals</a> page or
-contact the <a href="mailto:hep-sf-startup-team@googlegroups.com">startup team</a>.
+contact the <a href="mailto:hsf-coordination@googlegroups.com">startup team</a>.
     </p>
   </div>
   <div class="sidebar-module sidebar-module-inset">

--- a/calendar.md
+++ b/calendar.md
@@ -5,8 +5,8 @@ layout: default
 ---
 
 The HSF [Community Calendar](https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com){:target="_hsf_calendar"}
-can be edited by people in the [HSF Startup Team](https://groups.google.com/forum/#!forum/hep-sf-startup-team)
-or in the [HSF Calendar Editors Group](https://groups.google.com/forum/#!forum/hep-sf-calendar-editors) Google Groups.
+can be edited by people in the [HSF Startup Team](https://groups.google.com/forum/#!forum/hsf-coordination)
+or in the [HSF Calendar Editors Group](https://groups.google.com/forum/#!forum/hsf-calendar-editors) Google Groups.
 
 The most straight forward way to do this is to 
 

--- a/cwp/cwp-working-groups.md
+++ b/cwp/cwp-working-groups.md
@@ -165,7 +165,7 @@ Draft WG notes: [google doc](https://docs.google.com/document/d/1IGKQStDZm97PFZJ
 ### Careers, Staffing and Training WG ###
 Charge: [Google Doc](https://docs.google.com/document/d/1oHnZDMNWe_QTy4cQ8kNN_GDIW8wW1hAIKS8z2z05U2w/edit) 
 
-Google group: hep-sf-training-wg@googlegroups.com [(link to subscribe)](https://groups.google.com/forum/#!forum/hep-sf-training-wg)
+Google group: hsf-training-wg@googlegroups.com [(link to subscribe)](https://groups.google.com/forum/#!forum/hsf-training-wg)
 
 Plans:
 

--- a/events/_posts/2015-01-21-SLAC.md
+++ b/events/_posts/2015-01-21-SLAC.md
@@ -39,7 +39,7 @@ umbrella
 **In order to keep informed of community events like this, please join the 
 following lists**
 
- * [HSF forum](http://groups.google.com/forum/#!forum/hep-sf-forum): general 
+ * [HSF forum](http://groups.google.com/forum/#!forum/hsf-forum): general 
 discussions about HSF activities
  * [HEP Software and Computing 
 community](https://groups.google.com/forum/#!forum/hep-sw-comp) announcements 

--- a/events/_posts/2017-03-28-VisualizationWorkshop.md
+++ b/events/_posts/2017-03-28-VisualizationWorkshop.md
@@ -32,4 +32,4 @@ The agenda of the follow-up meeting can be found here: https://indico.cern.ch/ev
 
 *Update:*
 
-* 31 March 2017: A short [Workshop's summary report](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/hep-sf-forum/R6QefiZ3RUU/1xiO7kIiFAAJ) about the main workshop, which ended yesterday.
+* 31 March 2017: A short [Workshop's summary report](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/hsf-forum/R6QefiZ3RUU/1xiO7kIiFAAJ) about the main workshop, which ended yesterday.

--- a/forums.md
+++ b/forums.md
@@ -9,7 +9,7 @@ layout: default
 Discussions and activities in the HEP Software Foundation rely on several mailing lists and forums, some of them for general discussions, others for topical ones. All these forums are open to anybody interested and archives are publically available but they generally require that you register in order to participate.
 
 *Most of these forums are hosted by Google Groups. To register to them with your preferred email, simply send a mail to
-`forum_name+subscribe@googlegroups.com` (with `forum_name` replaced by the actual name, e.g. `hep-sf-tech`): subject and contents 
+`forum_name+subscribe@googlegroups.com` (with `forum_name` replaced by the actual name, e.g. `hsf-tech`): subject and contents 
 are ignored and can be empty. If you want to register with your Google account, you can also use the web page associated with the forum
 (see below).*
 
@@ -17,13 +17,13 @@ are ignored and can be empty. If you want to register with your Google account, 
 ## General Discussion Forums
 -----
 
-### General Information about HSF: hep-sf-forum@googlegroups.com
+### General Information about HSF: hsf-forum@googlegroups.com
 
-The [hep-sf-forum](http://groups.google.com/d/forum/hep-sf-forum) is the general announcement and discussion forum for the HSF. Our meeting announcements are posted here, as are meeting minutes, including minutes of the startup team meetings. The forum is intended for discussion, not just announcements. And everybody interested into the HSF, even though it is only for specific topic, is encourage to register to this forum to get all announcements. 
+The [hsf-forum](http://groups.google.com/d/forum/hsf-forum) is the general announcement and discussion forum for the HSF. Our meeting announcements are posted here, as are meeting minutes, including minutes of the startup team meetings. The forum is intended for discussion, not just announcements. And everybody interested into the HSF, even though it is only for specific topic, is encourage to register to this forum to get all announcements. 
 
-### HSF Technical Forum: hep-sf-tech-forum@googlegroups.com
+### HSF Technical Forum: hsf-tech-forum@googlegroups.com
 
-The [hep-sf-tech-forum](https://groups.google.com/forum/#%21forum/hep-sf-tech-forum) is the general open forum for technical discussions on HEP Software Foundation topics. Anyone subscribing here should be prepared for technical emails, so posters should not be shy about posting technical issues! Topics can be forked off to dedicated forums as appropriate.
+The [hsf-tech-forum](https://groups.google.com/forum/#%21forum/hsf-tech-forum) is the general open forum for technical discussions on HEP Software Foundation topics. Anyone subscribing here should be prepared for technical emails, so posters should not be shy about posting technical issues! Topics can be forked off to dedicated forums as appropriate.
 
 
 ### HEP S&C community mailing list: hep-sw-comp@googlegroups.com
@@ -50,7 +50,7 @@ R&D series of presentations and discussions. The goal is to probe the lesser kno
 
 The reconstruction algorithms discussion forum is an open forum to discuss all matters of event reconstruction and pattern recognition in high energy physics and similar domains. All are welcome to join the forum and participate.
 
-[Reconstruction Algorithms Forum ](https://groups.google.com/forum/#!forum/hep-sf-reconstruction)
+[Reconstruction Algorithms Forum ](https://groups.google.com/forum/#!forum/hsf-reconstruction)
 
 ### Machine Learning Forum
 The Inter-Experimental LHC Machine Learning Working Group [IML](http://iml.cern.ch/) has been launched recently. 
@@ -64,9 +64,9 @@ are discussed by the community.
 
 ---
 
-### HSF Training Activities: hep-sf-training-wg
-The [hep-sf-training-wg](https://groups.google.com/forum/#%21forum/hep-sf-training-wg) is the discussion forum for the training working group.
+### HSF Training Activities: hsf-training-wg
+The [hsf-training-wg](https://groups.google.com/forum/#%21forum/hsf-training-wg) is the discussion forum for the training working group.
 
-### HSF Packaging WG: hep-sf-packaging-wg
-The [hep-sf-packaging-wg](https://groups.google.com/forum/#%21forum/hep-sf-packaging-wg) is the discussion forum for the packaging working group.
+### HSF Packaging WG: hsf-packaging-wg
+The [hsf-packaging-wg](https://groups.google.com/forum/#%21forum/hsf-packaging-wg) is the discussion forum for the packaging working group.
 

--- a/get_involved.md
+++ b/get_involved.md
@@ -8,7 +8,7 @@ layout: default
 
 Our goal is to make every effort going on as transparent and open as possible.
 Our official communication channel is the 
-[hep-sf-forum](https://groups.google.com/forum/#!forum/hep-sf-forum). 
+[hsf-forum](https://groups.google.com/forum/#!forum/hsf-forum). 
 
 See the [dedicated page](/forums.html) about HSF discussions forums for 
 information about how to register and the
@@ -40,7 +40,7 @@ affiliated people when needed. See <https://account.cern.ch/account/Externals/>
 If you are not comfortable with raising an issue in the
 [forums](/forums.html) or if you are afraid that this is not the
 right place for it, feel free to contact the
-[HSF startup team](mailto:hep-sf-startup-team@googlegroups.com) directly.
+[HSF startup team](mailto:hsf-coordination@googlegroups.com) directly.
 
 ## Contributing to this website
 

--- a/newsletter.html
+++ b/newsletter.html
@@ -4,7 +4,7 @@ layout: newsletter_summary
 ---
 <div>
 The HSF Newsletter informs you about latest developments in the HEP Software Foundation. 
-To receive it, please subscribe to the <a href="http://groups.google.com/d/forum/hep-sf-forum">hep-sf-forum</a>.
+To receive it, please subscribe to the <a href="http://groups.google.com/d/forum/hsf-forum">hsf-forum</a>.
 </div>
 <div class="row">
 

--- a/newsletter/_posts/2015-12-18-PKG.md
+++ b/newsletter/_posts/2015-12-18-PKG.md
@@ -26,7 +26,7 @@ In summary, it was soon clear that both requirements and solutions are similar. 
 
 If you want to know more, join the packaging mailing list:
 
-    hep-sf-packaging-wg@googlegroups.com
+    hsf-packaging-wg@googlegroups.com
 
 
 Looking forward to your contributions and ideas!

--- a/newsletter/_posts/2017-02-01-CWPWorkshopSanDiego.md
+++ b/newsletter/_posts/2017-02-01-CWPWorkshopSanDiego.md
@@ -46,4 +46,4 @@ The work to deliver the CWP should happen over the next 5 months after which it 
 * HSF Analysis Ecosystem Workshop (a [Doodle](http://doodle.com/poll/wunez2afnmycg8tu) is open to fix dates) 
 * [DSHEP@FNAL](https://indico.fnal.gov/conferenceDisplay.py?confId=13497) (FNAL, May)
 
-Finally, please be sure to register to the [Community White Paper google group](https://groups.google.com/forum/#!forum/hsf-community-white-paper) and the general [HSF forum](mailto:hep-sf-forum@googlegroups.com) if you have not already done so.
+Finally, please be sure to register to the [Community White Paper google group](https://groups.google.com/forum/#!forum/hsf-community-white-paper) and the general [HSF forum](mailto:hsf-forum@googlegroups.com) if you have not already done so.

--- a/organization/_posts/2015-07-02-startup.md
+++ b/organization/_posts/2015-07-02-startup.md
@@ -10,7 +10,7 @@ Present: Dario, Andrea, Pere, Benedikt, Amber, Michel, Liz,
 Apologies: Torre, Andrew,
 
 ## Main messages from iFB meeting last week
-- Pere: Communication is something that we need to improve. Use the main mailing list [hep-sf-forum](http://groups.google.com/d/forum/hep-sf-forum) to post any relevant information. For example pointing to new topics being discussed in the other lists.  We need the HSF newsletter.
+- Pere: Communication is something that we need to improve. Use the main mailing list [hsf-forum](http://groups.google.com/d/forum/hsf-forum) to post any relevant information. For example pointing to new topics being discussed in the other lists.  We need the HSF newsletter.
 - Very few people present, somehow an extended startup team meeting
 - Shared the opinion that we need to improve on communication and achieving results. The lack of concrete results is a also a problem. Somehow a vicious cycle.
 - We should not be discouraged. Things will be better when concrete little achievements will be realized.

--- a/organization/_posts/2016-08-25-startup.md
+++ b/organization/_posts/2016-08-25-startup.md
@@ -65,7 +65,7 @@ Proposal to use our meeting slot for this initial discussion next week.
 -   There will be a Spack meeting today.
 
 -   Some discussion about Portage happened on the mailing list:
-    -  https://groups.google.com/forum/\#!topic/hep-sf-packaging-wg/xWnin-JPEzk
+    -  https://groups.google.com/forum/\#!topic/hsf-packaging-wg/xWnin-JPEzk
     -  For more information on Portage (article submitted to [*HUST*](http://hust16.github.io)), please take a look at https://github.com/heroxbd/hust/blob/master/portage.pdf
 
 SW&C Journal

--- a/organization/_posts/2017-03-30-startup.md
+++ b/organization/_posts/2017-03-30-startup.md
@@ -25,7 +25,7 @@ layout: default
 
 -   Visualization workshop taking place this week
 
-    -   [*Riccardo’s workshop summary*](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/hep-sf-forum/R6QefiZ3RUU/1xiO7kIiFAAJ)
+    -   [*Riccardo’s workshop summary*](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/hsf-forum/R6QefiZ3RUU/1xiO7kIiFAAJ)
 
 -   Computing model: chapter outline anticipated soon from Ian
 

--- a/organization/team.md
+++ b/organization/team.md
@@ -1,11 +1,11 @@
 ---
-title: "HSF Startup Team"
+title: "HSF Coordination Team"
 layout: default
 ---
 
-# HSF Startup Team
+# HSF Coordination Team
 
-Currently the activities within the HSF are organized by the *HSF startup team*. Following the concept of a do-ocracy active contributors to the HSF are invited to join. These are the current members of the startup team:
+Currently the activities within the HSF are organized by the *HSF coordination team* (formerly called the *startup team*). Following the concept of a do-ocracy active contributors to the HSF are invited to join. These are the current members of the team:
 
  * [Amber Boehnlein](https://www.jlab.org/div_dept/directorate/directors/ABoehnlein.html) - Jefferson Lab
  * [Peter Elmer](https://phy.princeton.edu/people/g-j-peter-elmer) - Princeton University
@@ -25,11 +25,11 @@ Currently the activities within the HSF are organized by the *HSF startup team*.
  * Brett Viren - [BNL](https://www.bnl.gov)
  * Torre Wenaus - [BNL](https://www.bnl.gov), co-lead
 
-The entire team can be contacted via <hep-sf-startup-team@googlegroups.com>.
+The entire team can be contacted via <hsf-coordination@googlegroups.com>.
 
 ## Meeting Minutes
 
-The startup team runs a regular HSF meeting (nominally, and usually, weekly) which is open to all. Meeting announcements and minutes are posted to the HSF open forum google group.
+The team runs the regular HSF meeting (nominally, and usually, weekly) which is open to all. Meeting announcements and minutes are posted to the HSF open forum google group.
 
 {:.table .table-hover .table-condensed .table-striped}
 | Date   | Title      |
@@ -39,7 +39,7 @@ The startup team runs a regular HSF meeting (nominally, and usually, weekly) whi
 
 [Full list of past minutes](/organization/minutes.html).
 
-## Presentations given by Startup Team Members
+## Presentations given by Coordination Team Members
  * [The HSF CWP](https://indico.desy.de/indico/event/18681/session/8/contribution/114/material/slides/0.pdf), [11th Terascale Alliance Workshop](https://indico.desy.de/indico/event/18681/), 28 Nov 2017, Benedikt Hegner
  * [The HSF CWP](https://indico.cern.ch/event/663273/contributions/2708178/attachments/1545100/2431717/HSF-CWP-Roadmap.pdf), [3rd Scientific Computing Forum](https://indico.cern.ch/event/663273/), 29 Oct 2017, Graeme Stewart
  * [HSF CWP Status](https://indico.cern.ch/event/578990/contributions/2720743/attachments/1522280/2381911/CWP_Status_-_GDB_20170913.pdf), WLCG GDBn, CERN, 13 Sep 2017, Michel Jouvin

--- a/projects.md
+++ b/projects.md
@@ -6,7 +6,7 @@ layout: default
 
 # HSF Projects
 
-HSF seeks to serve new and emerging common projects through a project incubator activity. Templates to guide and aid new projects are being established. If you'd like your project to be involved just let us know. Talk to any member of the startup team or email hep-sf-startup-team@googlegroups.com.
+HSF seeks to serve new and emerging common projects through a project incubator activity. Templates to guide and aid new projects are being established. If you'd like your project to be involved just let us know. Talk to any member of the startup team or email hsf-coordination@googlegroups.com.
 
 The incubator idea is close to the one of the Apache Software Foundation. Brian Van Klaveren who gave the exceptional ASF talk at the SLAC workshop provides [this link](http://www.apache.org/foundation/how-it-works.html#incubator) describing how ASF Incubator projects work.
 

--- a/services.md
+++ b/services.md
@@ -16,7 +16,7 @@ Message sent to the HSF forum on March 26 2015
 
 <div class="rteindent1" style="color: rgb(34, 34, 34); font-family: arial, sans-serif; font-size: 12.8000001907349px; line-height: normal;"> </div>
 
-<div class="rteindent1" style="color: rgb(34, 34, 34); font-family: arial, sans-serif; font-size: 12.8000001907349px; line-height: normal;">We invite people to get in touch with us who are interested to have their projects participate as an early adopter and guinea pig. Contact the startup team at <a href="mailto:hep-sf-startup-team@googlegroups.com" style="color: rgb(17, 85, 204);" target="_blank">hep-sf-startup-team@googlegroups.com</a>. </div>
+<div class="rteindent1" style="color: rgb(34, 34, 34); font-family: arial, sans-serif; font-size: 12.8000001907349px; line-height: normal;">We invite people to get in touch with us who are interested to have their projects participate as an early adopter and guinea pig. Contact the startup team at <a href="mailto:hsf-coordination@googlegroups.com" style="color: rgb(17, 85, 204);" target="_blank">hsf-coordination@googlegroups.com</a>. </div>
 
 ## TechForum interest list
 

--- a/technical_notes.md
+++ b/technical_notes.md
@@ -23,7 +23,7 @@ The Technical Notes policy is set out in the first technical note. Finalized not
 
 ## Drafts in the consultation stage
 
-Before being assigned an HSF reference and being archived in their final form, final drafts are published on the [hep-sf-forum](http://groups.google.com/d/forum/hep-sf-forum) mailing list by the technical notes series editor. In most cases, this consultation stage is intended to cover the formatting and language quality of the notes, rather than the substantive content which has already been decided by the relevant HSF activity or external project.
+Before being assigned an HSF reference and being archived in their final form, final drafts are published on the [hsf-forum](http://groups.google.com/d/forum/hsf-forum) mailing list by the technical notes series editor. In most cases, this consultation stage is intended to cover the formatting and language quality of the notes, rather than the substantive content which has already been decided by the relevant HSF activity or external project.
 
 {:.table .table-hover .table-condensed .table-striped}
 | Draft TN Reference  | Title           | Authors     | Ends    | Download    |

--- a/what_are_WGs.md
+++ b/what_are_WGs.md
@@ -8,7 +8,7 @@ layout: default
 
 Working Groups are ad-hoc formed groups of people interested in tackling a problem together. 
 If you want to form a working group or want to put some community-wide activity under the umbrella of the HSF,
-just contact the [HSF startup team](mailto:hep-sf-startup-team@googlegroups.com) and we will announce your activities here.
+just contact the [HSF startup team](mailto:hsf-coordination@googlegroups.com) and we will announce your activities here.
 
 Currently the following working groups are active within the HSF:
 


### PR DESCRIPTION
hep-sf-* -> hsf-*
hep-sf-startup-team -> hsf-coordination

All links and "current" content is updated, but purely hisorical
references to "startup team" were left in place.
