### PR TITLE
Announcement for restart of Software Dev meetings

### DIFF
--- a/announcements/_posts/2018-05-31-software-forum.md
+++ b/announcements/_posts/2018-05-31-software-forum.md
@@ -1,0 +1,9 @@
+---
+title:  Software Development Forum on DD4hep, 6 June 2018
+author: Graeme Stewart
+layout: newsletter
+symbol: glyphicon-calendar
+link: https://indico.cern.ch/event/733268/
+until: 2018-06-06
+---
+Software Forum: DD4hep Common Geometry


### PR DESCRIPTION
This adds a banner announcement to the website to advertise next week's meeting on DD4hep (link to Indico directly).
