### PR TITLE
Fix the proposed date for the software development tools meeting

### DIFF
--- a/organization/_posts/2018-05-24-coordination.md
+++ b/organization/_posts/2018-05-24-coordination.md
@@ -78,7 +78,7 @@ Visualization
 Software Development
 --------------------
 -   Martin, Giulio and Graeme met and we will have a Software
-    Development meeting on 13th June (taking this 15-16h slot). Aim is
+    Development meeting on 14th June (taking this 15-16h slot). Aim is
     to make progress and identify people wanting to work on
     performance & optimisation topics. Also proposing a BOF follow up
     at CHEP.

--- a/organization/_posts/2018-05-31-coordination.md
+++ b/organization/_posts/2018-05-31-coordination.md
@@ -81,7 +81,7 @@ Visualization
     
 Software Development
 --------------------
--   Meeting planned for 13 June.
+-   Meeting planned for 14 June.
 -   There will be a Geant4 developer position opened up in Pittsburgh -
     US ATLAS funded (more details as they are known).
 


### PR DESCRIPTION
Somehow the wrong date was added to the minutes in the last two weeks (I suspect my own confusion).