### PR TITLE
Add Software Dev Tools meeting announcement

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -35,7 +35,7 @@ The HSF has now submitted the
     {% assign stopdate = post.until | string_to_date | date: "%Y-%m-%d" %}
     {% if stopdate > sitedate %}
 <div class="row alert alert-warning">
-  <p class="lead">
+  <p class="lead event-announce">
     <span class="glyphicon {{ post.symbol }}" aria-hidden="true"></span> {{ post.title }} (<a href="{{ post.link }}">more info</a>)
   </p>
 </div>    

--- a/announcements/_posts/2018-06-08-software-dev-tools.md
+++ b/announcements/_posts/2018-06-08-software-dev-tools.md
@@ -1,0 +1,9 @@
+---
+title:  Software Development Tools Meeting, 14 June 2018
+author: Graeme Stewart
+layout: newsletter
+symbol: glyphicon-calendar
+link: https://indico.cern.ch/event/735132/
+until: 2018-06-14
+---
+Software Development Tools Meeting

--- a/css/hsf.css
+++ b/css/hsf.css
@@ -219,6 +219,10 @@ body {
 .lead {
   font-size: 20px;
 }
+.lead > a:hover {
+	color: #333333;
+}
+
 
 .alert {
   padding: 8px;

--- a/css/hsf.css
+++ b/css/hsf.css
@@ -219,7 +219,7 @@ body {
 .lead {
   font-size: 20px;
 }
-.lead > a:hover {
+.event-announce > a:hover {
 	color: #333333;
 }
 


### PR DESCRIPTION
Make a small CSS fix so that hovering over an annoucement link
does not make the link text invisible (as the text colour matched
the announcement background colour).