### PR TITLE
Remove link to broken site

### DIFF
--- a/organization/_posts/2018-03-01-startup.md
+++ b/organization/_posts/2018-03-01-startup.md
@@ -16,7 +16,7 @@ HSF/WLCG Workshop
         -   Some people did overpay, they are being reimbursed, but
             contact organisers if there is difficulty with that.
     -   The LOC produced a poster that can be
-        [downloaded](https://filesender.unina.it/filesender/?vid=48d79c11-8383-95c9-733f-0000585068b1)
+        downloaded (https://filesender.unina.it/filesender/?vid=48d79c11-8383-95c9-733f-0000585068b1)
         and printed.
     -   Further follow ups on participation:
         -   Liz was trying to encourage the head of LArSoft (Erica) to


### PR DESCRIPTION
Download has expired, so don't try to link to it anymore (keep URL as text for "history").