### PR TITLE
Use the HSF build of the docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install: /bin/true
  
 script:
-  - docker run --volume $(pwd):/srv/jekyll --interactive --tty --user $(id -u) --env HOME=/tmp graemeastewart/hsf-jekyll /bin/sh -c /srv/jekyll/.travis-scripts/html-proofer
+  - docker run --volume $(pwd):/srv/jekyll --interactive --tty --user $(id -u) --env HOME=/tmp hepsoftwarefoundation/hsf-jekyll /bin/sh -c /srv/jekyll/.travis-scripts/html-proofer
 
 # branch whitelist, only for GitHub Pages
 branches:


### PR DESCRIPTION
I started making sure that we update the HSF docker container for Jekyll now, but the way that Travis runs needs then to be adjusted (it used to use my "personal" container).

Changing this will fix the problem with the INFN Milano site as I just updated hepsoftwarefoundation/hsf-jekyll with the missing certificate:

https://github.com/HSF/docker/commit/42cd2b9bb1f405a0ae65f733fd5046dec9a29240
