### PR TITLE
Meeting minutes

### DIFF
--- a/organization/_posts/2018/2018-04-23-training.md
+++ b/organization/_posts/2018/2018-04-23-training.md
@@ -1,0 +1,44 @@
+---
+title: "HSF Training and Careers Working Group Meeting, 23 April, 2018"
+layout: default
+---
+
+# {{page.title}}
+
+#### Attendees: Albert Puig Navarro (LHCb) , Dario Berzano (ALICE), Dario Menasce (CMS), David Lange (CMS), Francesco Giacomini (Bertinoro School), Ilya (Belle II), Louise Heelan (ATLAS), Markus Schulz (CERN IT), Martin Ritter (Belle II), Rob Kutschke (Mu2e/Neutrino FNAL), Servesh Muralidharan (CERN IT), Sudhir Malik (CMS)
+
+- Attendees introduced themselves as it is big spectrum of people
+- A bit about attendees role in their respective experiments/labs/
+    - Albert Puig Navarro and Dario Berzano (Coordinate StarteKit at LHCb and ALICE)
+    - Dario Menasce (CMS HSF Starter group/ Sci Comp Committee)
+    - David Lange (CMS Software infrastructure)
+    - Francesco Giacomini – (Bertinoro School of Computing/ Yearly held in October)
+    - Ilya – (Coordinate Documentation and training/software/outreach in Belle2)
+    - Louise Heelan – (Train/documentation coordinator/ 5-day
+            analysis/workshop/analysis workbook in ATLAS)
+    - Markus Schulz – (CERN IT Performance Team, improving computing efficiency to
+            meet HL-LHC demand)
+    - Rob Kutschke – FNAL/Mu2e head of Comp. & Soft./develop training material for ART
+            framework used by neutrino experiments at Fermilab)
+    - Servesh Muralidharan – Interested in Training and improving performance of HEP
+            code)
+    - Martin Ritter – HSF representative of Belle II and framework and software
+            infrastructure responsible at Belle II
+    - Sudhir Malik - User Support co-coordinator at CMS/ Chair of CMS Schools
+            Committee/CMS Data Analysis School
+
+- Meeting highlights – building a federation of training activities across experiments
+  specific training and non-experiment computing schools
+
+    - Start with putting together a google doc with info on dates of experiment
+      specific/non-specific training activities. Click here(do right click)
+      https://goo.gl/Kwbk73 for google doc.
+    - Later have a website to show training schedules and public material -
+      presentations/good software related examples/exercises and best
+      practices/reference material
+    - Training material at three tiers
+        - Lower - examples - Linux/C++/Python
+        - Medium – ROOT/Geant4
+        - High – Machine Learning/ GPUs/ Developer level
+    - Try to share teachers/lecturers among schools atleast on common topics and
+      build a community sense

--- a/organization/_posts/2018/2018-04-23-training.md
+++ b/organization/_posts/2018/2018-04-23-training.md
@@ -9,7 +9,7 @@ layout: default
 
 - Attendees introduced themselves as it is big spectrum of people
 - A bit about attendees role in their respective experiments/labs/
-    - Albert Puig Navarro and Dario Berzano (Coordinate StarteKit at LHCb and ALICE)
+    - Albert Puig Navarro and Dario Berzano (Coordinate StarterKit at LHCb and ALICE)
     - Dario Menasce (CMS HSF Starter group/ Sci Comp Committee)
     - David Lange (CMS Software infrastructure)
     - Francesco Giacomini – (Bertinoro School of Computing/ Yearly held in October)
@@ -40,5 +40,5 @@ layout: default
         - Lower - examples - Linux/C++/Python
         - Medium – ROOT/Geant4
         - High – Machine Learning/ GPUs/ Developer level
-    - Try to share teachers/lecturers among schools atleast on common topics and
+    - Try to share teachers/lecturers among schools at least on common topics and
       build a community sense

--- a/organization/_posts/2018/2018-07-18-softwareforum.md
+++ b/organization/_posts/2018/2018-07-18-softwareforum.md
@@ -1,0 +1,55 @@
+---
+title: "HSF Software Forum on Vectorisation Tools, 18 July, 2018"
+layout: default
+---
+
+# {{page.title}}
+
+[Meeting Agenda and Slides](https://indico.cern.ch/event/736105/) 
+
+Introduction
+============
+-   Next meetings being planned, 
+    [check Indico for the status](https://indico.cern.ch/category/10392/). Please 
+    send any suggestions for presentations or discussion topics.
+
+VecCore
+=======
+-   Why does CPU go down between 2027-2030 in the CMS plot? A. 
+    It's a guess that 10%
+    optimisation can be found every year, based on previous experience
+    in CMS.
+-   Quadratic benchmark shows that icc does vectorise very well, but
+    noted that this is only for simple cases - it still doesn't work
+    for complex cases or branchy code (otherwise we'd just buy icc!).
+    More recent versions of gcc and clang do better than the versions
+    in the plots.
+-   User code needs to choose the backend. Can do this as a typedef, so
+    that one can easily switch. Is this adaptable to large code bases
+    that may have different sweet spots? Yes, it can be made fairly
+    independent of the 'core' code.
+-   C++ standard evolution? It's discussed, but not clear when it will come. Can
+    add the standard as another backend when it's available. Some
+    algorithms may work more efficiently with short vectors. Alignment
+    is a problem - has had very poor support in C++, but much improved
+    in C++17 (compiler directive available).
+-   ISPC compiler considered R&D project by Intel - it's now an open
+    source project, but future not clear.
+    
+SOAContainer
+============
+-   Will the loop vectorise properly on slides 17, 18? A. Yes - the
+    compilers will vectorise that.
+-   Intel's Arrow Street? No experience with that.
+-   Marco C - way to use it has improved a lot.
+    -   Can the results be serialised by ROOT? Not tried yet. Would need
+        to perhaps manipulate the data to serialise (costs a bit).
+-   Frank - looks a lot like xAOD and its features.
+-   Guilhereme - could this be a view of the data that's in ROOT, as a
+    split tree.
+    -   Problem is that in memory representation is row-wise again.
+    -   Only really take advantage of columns in analysis (usually).
+-   Is there another way to do it than macros?
+    -   It can be done without the marcos, but requires a lot of boiler
+        plate, which is rather worse.
+

--- a/organization/_posts/2018/2018-07-18-softwareforum.md
+++ b/organization/_posts/2018/2018-07-18-softwareforum.md
@@ -15,10 +15,10 @@ Introduction
 
 VecCore
 =======
--   Why does CPU go down between 2027-2030 in the CMS plot? A. 
-    It's a guess that 10%
-    optimisation can be found every year, based on previous experience
-    in CMS.
+-   Why does CPU go down between 2027-2030 in the CMS plot? 
+    - It's a guess that 10%
+      optimisation can be found every year, based on previous experience
+      in CMS.
 -   Quadratic benchmark shows that icc does vectorise very well, but
     noted that this is only for simple cases - it still doesn't work
     for complex cases or branchy code (otherwise we'd just buy icc!).
@@ -26,8 +26,9 @@ VecCore
     in the plots.
 -   User code needs to choose the backend. Can do this as a typedef, so
     that one can easily switch. Is this adaptable to large code bases
-    that may have different sweet spots? Yes, it can be made fairly
-    independent of the 'core' code.
+    that may have different sweet spots? 
+    - Yes, it can be made fairly
+      independent of the 'core' code.
 -   C++ standard evolution? It's discussed, but not clear when it will come. Can
     add the standard as another backend when it's available. Some
     algorithms may work more efficiently with short vectors. Alignment

--- a/organization/_posts/2018/2018-07-19-coordination.md
+++ b/organization/_posts/2018/2018-07-19-coordination.md
@@ -1,0 +1,152 @@
+---
+title: "HSF Weekly Meeting #142, 18 July, 2018"
+layout: default
+---
+
+# {{page.title}}
+
+#### *Present/Contributors*: Graeme Stewart, Andrea Valassi, Dario Menasce, Benedikt Hegner
+
+News, general matters
+=====================
+-   Graeme gave an update on HSF activities in the
+    [GDB](https://indico.cern.ch/event/651355/).
+    
+CHEP Matters
+============
+
+PyHEP
+-----
+-   General comments:
+    -   70 people attended, providing excellent representation from most
+        LHC experiments, Belle II and smaller experiments. Also lots
+        of IT/lab representation.
+    -   Workshop ran very smoothly - thank you to the CHEP chairs and
+        LOC help.
+    -   So far only received very positive feedback from participants.
+    -   Pre-workshop questionnaire was very useful and interesting. 70%
+        of participants filled it in - really appreciated.
+-   Key take-away topics:
+    -   (More details in our close-out presentation.)
+    -   Python strong in HEP data analysis, and usage likely to grow
+        further.
+    -   Binding Python to other languages is important and the future of
+        cppyy from the ROOT team sounds excellent.
+    -   Robust distribution of Python ( several versions, so at least
+        2.7 and 3.x) is a non-trivial problem that needs attention.
+    -   Education and training: lots of discussion and topic seen as
+        very important. Welcome the build of a community and training
+        material such as the StarterKit material.
+    -   Migration to Python 3. Far easier for analysts than for
+        experiments code for example. Still, a large fraction of the
+        community already uses Python 3, hence support is not to be
+        underestimated.
+    -   Core software is also using Python a fair bit.
+-   Outcomes and future
+    -   General feedback that workshop series should continue.
+    -   Consensus on need to build a community of interested users and
+        developers.
+        -   A Gitter channel has been set-up and will soon be
+            advertised.
+    -   Need to link with HSF efforts on training and education -
+        repository of expertise in in Python in HEP is welcome, for
+        example an inventory of appropriate tools.
+        -   We already got the StarterKit material moved out of LHCb
+            onto an HSF training repository, as an action forward.
+    -   We will very likely prepare a short post-workshop survey, to
+        help directing the future steps.
+    -   We started discussing the future of PyHEP among organisers. We
+        will bring in 2 extra persons: one from the IF/neutrino
+        community, another from an astroparticle physics experiment,
+        to have good coverage across the broad community.
+      
+
+Activity updates
+================
+
+Training
+--------
+-   GridKa School of Computing asked to use again the WikiToLearn
+    platform to publish their training material of this year's
+    lessons. People in charge of WTL kindly provided the necessary
+    hook.
+    
+Software Forum
+--------------
+-   Met yesterday, 18 July, discussed VecCore and SOAContainer ([minutes](/organization/2018/07/18/softwareforum.html)).
+-   Meetings for after summer now being planned - please suggest and
+    volunteer subjects to cover. [Check Indico for booked slots](https://indico.cern.ch/category/10392/).
+    
+Technical Notes
+---------------
+-   Graeme sent an email with the status of [HSF Platform Naming
+    Conventions](https://github.com/HSF/documents/tree/master/HSF-TN/2018-01)
+    and [HSF Project Best
+    Practices](https://github.com/HSF/documents/tree/master/HSF-TN/draft-2016-PROJ)
+    (for the latter, feedback before 31/7/2018).
+    
+Generators Software Re-engineering Workshop
+===========================================
+-   Andrea: had a chat with Michelangelo Mangano before CHEP together
+    with Witek and Graeme. Following his suggestions and some
+    discussions, we now aim for:
+    -   A "bootstrap" workshop of 2-3 days, possibly before the LHCC
+        review (which according to Graeme is now scheduled around
+        March 2019).
+    -   Possibly, a later one-week workshop to do some real work with
+        the experts.
+    -   For both events, Michelangelo suggested that the LPCC (LHC
+        Physics Centre at CERN) could host them at CERN and possibly
+        provide some support. Indeed CERN seems easier logistically
+        for an event on a short timescale.
+    -   Graeme sent to Michelangelo the [current draft document](https://docs.google.com/document/d/1q0yErmSjYJOepESRs3bqjrF78oo0Y0QfjR3K93naJKU/edit?usp=sharing)
+        so that he can discuss this with colleagues and suggest a list
+        of participants.
+        
+CWP
+===
+-   ### General Matters and Roadmap
+    -   HSF Editorial Board got its ORCID rejected
+-   ### Publication status for Individual WG Papers
+    -   Graeme updated
+        [https://hepsoftwarefoundation.org/organization/cwp.html](https://hepsoftwarefoundation.org/organization/cwp.html)
+    -   **Machine Learning**
+        -   Published:
+            [https://arxiv.org/abs/1807.02876](https://arxiv.org/abs/1807.02876)
+            -   Minor update planned
+    -   **Software Trigger and Event Reconstruction**
+        -   Still needs to go to HSF repo
+    -   **Careers, Staffing and Training**
+        -   Published:
+            [https://arxiv.org/abs/1807.02875](https://arxiv.org/abs/1807.02875)
+            -   Minor update to author list to come
+
+AOB
+===
+-   HSF Logo in vector format - reminder of action on Benedikt.
+-   Next HSF/WLCG workshop
+    -   We started discussing when and where to have the next workshop.
+        Boundary conditions are:
+        -   There will be a pre-CHEP workshop next year (2-3
+            November 2019).
+        -   LHCC review of HL-LHC software and computing next Spring
+            (exact dates and topics to be decided by LHCC in due
+            course). Would like to use this workshop to prepare.
+    -   Thus end of January, beginning February looks ideal. However...
+        -   Belle II Week + Review is 4-13 Feb.
+        -   w/b 18 Feb is school holiday (FR + CH).
+    -   General support for going to US, East Coast is a bit easier and
+        cheaper (than the US West coast), but weather could be a
+        problem.
+        -   GDB yesterday argued we should have a European option as
+            well (maybe cheaper overall? especially given an expensive
+            CHEP next year).
+    -   We have a fairly firm offer from JLab to host. Offer from BNL/NY
+        being prepared.
+-   Graeme will give a talk at ECFA tomorrow
+    ([https://indico.cern.ch/event/730568/](https://indico.cern.ch/event/730568/))
+    -   Andrea: saw that there is a session on "individual recognition"
+        just after Graeme's talk. Unless I misunderstand, this would
+        be a useful place to raise the issues of software careers and
+        citation, and generally recognition of software/computing work
+        by individuals.

--- a/organization/_posts/2018/2018-07-19-coordination.md
+++ b/organization/_posts/2018/2018-07-19-coordination.md
@@ -1,11 +1,11 @@
 ---
-title: "HSF Weekly Meeting #142, 18 July, 2018"
+title: "HSF Weekly Meeting #142, 19 July, 2018"
 layout: default
 ---
 
 # {{page.title}}
 
-#### *Present/Contributors*: Graeme Stewart, Andrea Valassi, Dario Menasce, Benedikt Hegner
+#### *Present/Contributors*: Graeme Stewart, Andrea Valassi, Dario Menasce, Benedikt Hegner, Eduardo Rodrigues
 
 News, general matters
 =====================


### PR DESCRIPTION
Write up the meeting minutes from last week's HSF meetings, plus also make an HSF website version of the minutes from the training meeting that were only posted as PDF to that agenda (this is then an examplar version for the organisers).
