### PR TITLE
Implement forward-backwards navigation in meeting minutes

### DIFF
--- a/_layouts/meetings.html
+++ b/_layouts/meetings.html
@@ -21,20 +21,39 @@
 <div class="PageNavigation">
 
 {% if page.next_in_category %}
-  <a href="{{ page.next_in_category.url }}">{{ page.next_in_category.title }}</a>
+  <p class="alignleft"><a href="{{ page.next_in_category.url }}"> &#8592;&nbsp;{{ page.next_in_category.title }}</a></p>
 {% endif %}
 
  {% if page.previous_in_category %}
-  <a href="{{ page.previous_in_category.url }}">{{ page.previous_in_category.title }}</a>
+  <p class="alignright"><a href="{{ page.previous_in_category.url }}">{{ page.previous_in_category.title }} &nbsp;&#8594;</a></p>
 
 {% endif %}
 
 </div>
 
+<div style="clear: both;"></div>
+
+<hr>
+
   {{ content }}
 
-<br><br>
 <hr>
+
+
+<div class="PageNavigation">
+
+{% if page.next_in_category %}
+  <p class="alignleft"><a href="{{ page.next_in_category.url }}"> &#8592;&nbsp;{{ page.next_in_category.title }}</a></p>
+{% endif %}
+
+{% if page.previous_in_category %}
+  <p class="alignright"><a href="{{ page.previous_in_category.url }}">{{ page.previous_in_category.title }} &nbsp;&#8594;</a></p>
+{% endif %}
+
+  </div>
+
+  <div style="clear: both;"></div>
+<br><br>
 <div class="footer fixed-bottom">
 Thanks to <a href="https://pages.github.com/">GitHub Pages</a>, <a href="http://jekyllrb.com/">Jekyll</a> and <a href="http://getbootstrap.com/">Bootstrap</a>
 </div>

--- a/_layouts/meetings.html
+++ b/_layouts/meetings.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
+    <title>{{ page.title }}</title>
+    <link rel="icon" type="image/x-icon" href="{{ "/images/hsf_logo_angled.png" | prepend: site.baseurl }}">
+
+    <!-- bootstrap framework -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.5/flatly/bootstrap.min.css">
+
+    <link rel="stylesheet" href="/css/hsf.css" type="text/css" />
+</head>
+<body>
+{% include navbar.ext %}
+
+<div class="container">
+
+
+<div class="PageNavigation">
+
+{% if page.next_in_category %}
+  <a href="{{ page.next_in_category.url }}">{{ page.next_in_category.title }}</a>
+{% endif %}
+
+ {% if page.previous_in_category %}
+  <a href="{{ page.previous_in_category.url }}">{{ page.previous_in_category.title }}</a>
+
+{% endif %}
+
+</div>
+
+  {{ content }}
+
+<br><br>
+<hr>
+<div class="footer fixed-bottom">
+Thanks to <a href="https://pages.github.com/">GitHub Pages</a>, <a href="http://jekyllrb.com/">Jekyll</a> and <a href="http://getbootstrap.com/">Bootstrap</a>
+</div>
+
+</div> <!-- container -->
+
+
+<!-- Google Analytics -->
+
+<!-- Google Analytics end -->
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/_plugins/generate.rb
+++ b/_plugins/generate.rb
@@ -1,0 +1,27 @@
+
+
+module Jekyll
+  class WithinCategoryPostNavigation < Generator
+    def generate(site)
+      site.categories.each_pair do |category, posts|
+        posts.sort! { |a,b| b <=> a}
+        posts.each do |post|
+          index = posts.index post
+          next_in_category = nil
+          previous_in_category = nil
+          if index
+            if index < posts.length - 1
+              next_in_category = posts[index + 1]
+            end
+          	if index > 0
+              previous_in_category = posts[index - 1]
+            end
+          end
+          post.data["next_in_category"] = next_in_category unless next_in_category.nil?
+          post.data["previous_in_category"] = previous_in_category unless previous_in_category.nil?
+        end
+      end
+    end
+  end
+end
+

--- a/css/hsf.css
+++ b/css/hsf.css
@@ -240,3 +240,10 @@ body {
 [role="button"] {
     font-size: 17px;
 }
+
+.alignleft {
+  float: left;
+}
+.alignright {
+  float: right;
+}

--- a/organization/_posts/2014/2014-07-16-ifb.md
+++ b/organization/_posts/2014/2014-07-16-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #1"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Jul 16 2014

--- a/organization/_posts/2014/2014-09-07-ifb.md
+++ b/organization/_posts/2014/2014-09-07-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #2"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Sep 7 2014

--- a/organization/_posts/2014/2014-09-17-ifb.md
+++ b/organization/_posts/2014/2014-09-17-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #3"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Sep 17 2014

--- a/organization/_posts/2014/2014-10-08-startup.md
+++ b/organization/_posts/2014/2014-10-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #1"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation startup team meeting notes, Oct 8 2014

--- a/organization/_posts/2014/2014-10-15-startup.md
+++ b/organization/_posts/2014/2014-10-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #2"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation startup team meeting notes, Oct 15 2014

--- a/organization/_posts/2014/2014-10-22-ifb.md
+++ b/organization/_posts/2014/2014-10-22-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #4"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Oct 22 2014

--- a/organization/_posts/2014/2014-10-23-startup.md
+++ b/organization/_posts/2014/2014-10-23-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #3"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation startup team meeting notes, Oct 23 2014

--- a/organization/_posts/2014/2014-10-27-startup.md
+++ b/organization/_posts/2014/2014-10-27-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #4"
-layout: default
+layout: meetings
 ---
 
 https://indico.cern.ch/event/349273/

--- a/organization/_posts/2014/2014-11-05-ifb.md
+++ b/organization/_posts/2014/2014-11-05-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #5"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Nov 5 2014

--- a/organization/_posts/2014/2014-11-10-startup.md
+++ b/organization/_posts/2014/2014-11-10-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #5"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Nov 10 2014

--- a/organization/_posts/2014/2014-11-17-startup.md
+++ b/organization/_posts/2014/2014-11-17-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #6"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team meeting notes, Nov 17 2014

--- a/organization/_posts/2014/2014-11-26-startup.md
+++ b/organization/_posts/2014/2014-11-26-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #7"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Nov 26 2014

--- a/organization/_posts/2014/2014-12-03-ifb.md
+++ b/organization/_posts/2014/2014-12-03-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #6"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Dec 3 2014

--- a/organization/_posts/2014/2014-12-08-startup.md
+++ b/organization/_posts/2014/2014-12-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #8"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team meeting notes, Dec 8 2014

--- a/organization/_posts/2014/2014-12-15-startup.md
+++ b/organization/_posts/2014/2014-12-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #9"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team meeting notes, Dec 15 2014

--- a/organization/_posts/2014/2014-12-22-startup.md
+++ b/organization/_posts/2014/2014-12-22-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #10"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team meeting notes, Dec 22 2014

--- a/organization/_posts/2015/2015-01-05-startup.md
+++ b/organization/_posts/2015/2015-01-05-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #11"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team meeting notes, Jan 5 2015

--- a/organization/_posts/2015/2015-01-07-ifb.md
+++ b/organization/_posts/2015/2015-01-07-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #7"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Jan 7 2015

--- a/organization/_posts/2015/2015-01-12-startup.md
+++ b/organization/_posts/2015/2015-01-12-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #12"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Jan 12 2015

--- a/organization/_posts/2015/2015-02-10-startup.md
+++ b/organization/_posts/2015/2015-02-10-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #13"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Feb 10 2015

--- a/organization/_posts/2015/2015-02-16-startup.md
+++ b/organization/_posts/2015/2015-02-16-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #14"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Feb 16 2015

--- a/organization/_posts/2015/2015-02-23-startup.md
+++ b/organization/_posts/2015/2015-02-23-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #15"
-layout: default
+layout: meetings
 ---
 
 # Meeting notes for the Feb 23 2015 HSF startup team meeting

--- a/organization/_posts/2015/2015-03-02-startup.md
+++ b/organization/_posts/2015/2015-03-02-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #16"
-layout: default
+layout: meetings
 ---
 
 # Meeting notes for the Mar 2 2015 HSF startup team meeting

--- a/organization/_posts/2015/2015-03-04-ifb.md
+++ b/organization/_posts/2015/2015-03-04-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #8"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Mar 4 2015

--- a/organization/_posts/2015/2015-03-16-startup.md
+++ b/organization/_posts/2015/2015-03-16-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #17"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Mar 16 2015

--- a/organization/_posts/2015/2015-03-23-startup.md
+++ b/organization/_posts/2015/2015-03-23-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #18"
-layout: default
+layout: meetings
 ---
 
 # HSF startup team Mar 23 2015 meeting notes

--- a/organization/_posts/2015/2015-03-30-startup.md
+++ b/organization/_posts/2015/2015-03-30-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #19"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Mar 30 2015

--- a/organization/_posts/2015/2015-04-20-startup.md
+++ b/organization/_posts/2015/2015-04-20-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #20"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Apr 20 2015

--- a/organization/_posts/2015/2015-04-27-startup.md
+++ b/organization/_posts/2015/2015-04-27-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #21"
-layout: default
+layout: meetings
 ---
 # HSF startup team Apr 27 2015 meeting notes
 

--- a/organization/_posts/2015/2015-05-04-startup.md
+++ b/organization/_posts/2015/2015-05-04-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #22"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes May 4 2015

--- a/organization/_posts/2015/2015-05-11-startup.md
+++ b/organization/_posts/2015/2015-05-11-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #23"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes May 11 2015

--- a/organization/_posts/2015/2015-05-18-startup.md
+++ b/organization/_posts/2015/2015-05-18-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #24"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes May 18 2015

--- a/organization/_posts/2015/2015-06-01-startup.md
+++ b/organization/_posts/2015/2015-06-01-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #25"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Jun 1 2015

--- a/organization/_posts/2015/2015-06-08-startup.md
+++ b/organization/_posts/2015/2015-06-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #26"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Jun 8 2015

--- a/organization/_posts/2015/2015-06-15-startup.md
+++ b/organization/_posts/2015/2015-06-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #27"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Jun 15 2015

--- a/organization/_posts/2015/2015-06-22-startup.md
+++ b/organization/_posts/2015/2015-06-22-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #28"
-layout: default
+layout: meetings
 ---
 # Meeting notes for the June 22, 2015 startup team meeting
 

--- a/organization/_posts/2015/2015-06-24-ifb.md
+++ b/organization/_posts/2015/2015-06-24-ifb.md
@@ -1,6 +1,6 @@
 ---
 title: "Interim Foundation Board Meeting #9"
-layout: default
+layout: meetings
 ---
 
 # HSF Interim Foundation Board Meeting - Jun 24 2015

--- a/organization/_posts/2015/2015-07-02-startup.md
+++ b/organization/_posts/2015/2015-07-02-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #29"
-layout: default
+layout: meetings
 ---
 # Meeting notes for the July 2, 2015 startup team meeting
 [Indico Agenda](https://indico.cern.ch/event/405001/)

--- a/organization/_posts/2015/2015-07-09-startup.md
+++ b/organization/_posts/2015/2015-07-09-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #30"
-layout: default
+layout: meetings
 ---
 
 # Meeting notes for the July 9, 2015 startup team meeting

--- a/organization/_posts/2015/2015-07-16-startup.md
+++ b/organization/_posts/2015/2015-07-16-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #31"
-layout: default
+layout: meetings
 ---
 # Meeting notes for the July 16, 2015 startup team meeting
 

--- a/organization/_posts/2015/2015-09-25-startup.md
+++ b/organization/_posts/2015/2015-09-25-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #32"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Sep 25 2015

--- a/organization/_posts/2015/2015-10-01-startup.md
+++ b/organization/_posts/2015/2015-10-01-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #33"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Oct 1 2015

--- a/organization/_posts/2015/2015-10-08-startup.md
+++ b/organization/_posts/2015/2015-10-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #34"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Oct 8 2015

--- a/organization/_posts/2015/2015-10-15-startup.md
+++ b/organization/_posts/2015/2015-10-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #35"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Oct 15 2015

--- a/organization/_posts/2015/2015-10-22-startup.md
+++ b/organization/_posts/2015/2015-10-22-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #36"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Oct 22 2015

--- a/organization/_posts/2015/2015-10-29-startup.md
+++ b/organization/_posts/2015/2015-10-29-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #37"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Oct 29 2015

--- a/organization/_posts/2015/2015-11-05-startup.md
+++ b/organization/_posts/2015/2015-11-05-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #38"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Nov 5 2015

--- a/organization/_posts/2015/2015-11-19-startup.md
+++ b/organization/_posts/2015/2015-11-19-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #39"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Nov 19 2015

--- a/organization/_posts/2015/2015-12-10-startup.md
+++ b/organization/_posts/2015/2015-12-10-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #40"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Dec 10 2015

--- a/organization/_posts/2016/2016-01-14-startup.md
+++ b/organization/_posts/2016/2016-01-14-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #41"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Jan 14 2016

--- a/organization/_posts/2016/2016-01-21-startup.md
+++ b/organization/_posts/2016/2016-01-21-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #42"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Jan 21 2016

--- a/organization/_posts/2016/2016-01-28-startup.md
+++ b/organization/_posts/2016/2016-01-28-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #43"
-layout: default
+layout: meetings
 ---
 
 # HEP Software Foundation Startup Team Meeting notes Jan 28 2016

--- a/organization/_posts/2016/2016-02-04-startup.md
+++ b/organization/_posts/2016/2016-02-04-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #44"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team Meeting Feb 4 2016

--- a/organization/_posts/2016/2016-02-11-startup.md
+++ b/organization/_posts/2016/2016-02-11-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #45"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team Meeting Feb 11 2016

--- a/organization/_posts/2016/2016-02-18-startup.md
+++ b/organization/_posts/2016/2016-02-18-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "Startup Team Minutes #46"
-layout: default
+layout: meetings
 ---
 
 # HSF Startup Team Meeting Feb 18 2016

--- a/organization/_posts/2016/2016-02-25-startup.md
+++ b/organization/_posts/2016/2016-02-25-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #47, Feb 25 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #47 25/02/16

--- a/organization/_posts/2016/2016-03-03-startup.md
+++ b/organization/_posts/2016/2016-03-03-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #48, Mar 3 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #48 03/03/16

--- a/organization/_posts/2016/2016-03-10-startup.md
+++ b/organization/_posts/2016/2016-03-10-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #49, Mar 10 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #49 10/03/16

--- a/organization/_posts/2016/2016-03-24-startup.md
+++ b/organization/_posts/2016/2016-03-24-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #50, Mar 24 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #50 24/03/16

--- a/organization/_posts/2016/2016-04-07-startup.md
+++ b/organization/_posts/2016/2016-04-07-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #51, Apr 7 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #51 07/04/16

--- a/organization/_posts/2016/2016-04-14-startup.md
+++ b/organization/_posts/2016/2016-04-14-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #52, Apr 14 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #52 14/04/16

--- a/organization/_posts/2016/2016-04-21-startup.md
+++ b/organization/_posts/2016/2016-04-21-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #53, Apr 21 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #53 21/04/16

--- a/organization/_posts/2016/2016-04-28-startup.md
+++ b/organization/_posts/2016/2016-04-28-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #54, Apr 28 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #54 28/04/16

--- a/organization/_posts/2016/2016-05-04-Workshop-summary.md
+++ b/organization/_posts/2016/2016-05-04-Workshop-summary.md
@@ -1,6 +1,6 @@
 ---
 title: "Third HSF Workshop Summary (May 2-4 2016, LAL)"
-layout: default
+layout: meetings
 ---
 
 # Third HSF Workshop Summary (May 2-4, 2016)

--- a/organization/_posts/2016/2016-05-12-startup.md
+++ b/organization/_posts/2016/2016-05-12-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #55, May 12 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly #55 12/05/16

--- a/organization/_posts/2016/2016-05-19-startup.md
+++ b/organization/_posts/2016/2016-05-19-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #56, May 19 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #56, May 19 2016

--- a/organization/_posts/2016/2016-05-26-startup.md
+++ b/organization/_posts/2016/2016-05-26-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #57, May 26 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #57, May 26 2016

--- a/organization/_posts/2016/2016-06-09-startup.md
+++ b/organization/_posts/2016/2016-06-09-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #58, June 9, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #58, June 9, 2016

--- a/organization/_posts/2016/2016-06-16-startup.md
+++ b/organization/_posts/2016/2016-06-16-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #59, June 16, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #59, June 16, 2016

--- a/organization/_posts/2016/2016-06-23-startup.md
+++ b/organization/_posts/2016/2016-06-23-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #60, June 23, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #60, June 23, 2016

--- a/organization/_posts/2016/2016-06-30-startup.md
+++ b/organization/_posts/2016/2016-06-30-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #61, June 30, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #61, June 30, 2016

--- a/organization/_posts/2016/2016-07-07-startup.md
+++ b/organization/_posts/2016/2016-07-07-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #62, July 7, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #62, July 7, 2016

--- a/organization/_posts/2016/2016-07-14-startup.md
+++ b/organization/_posts/2016/2016-07-14-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #63, July 14, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #63, July 14, 2016

--- a/organization/_posts/2016/2016-07-21-startup.md
+++ b/organization/_posts/2016/2016-07-21-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #64, July 21, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #64, July 21, 2016

--- a/organization/_posts/2016/2016-07-28-startup.md
+++ b/organization/_posts/2016/2016-07-28-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #65, July 28, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #65, July 28, 2016

--- a/organization/_posts/2016/2016-08-25-startup.md
+++ b/organization/_posts/2016/2016-08-25-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #66, August 25, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #66, August 25, 2016

--- a/organization/_posts/2016/2016-09-01-startup.md
+++ b/organization/_posts/2016/2016-09-01-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #67, September 1, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #67, September 1, 2016

--- a/organization/_posts/2016/2016-09-08-startup.md
+++ b/organization/_posts/2016/2016-09-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #68, September 8, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #68, September 8, 2016

--- a/organization/_posts/2016/2016-09-15-startup.md
+++ b/organization/_posts/2016/2016-09-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #69, September 15, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #69, September 15, 2016

--- a/organization/_posts/2016/2016-11-03-startup.md
+++ b/organization/_posts/2016/2016-11-03-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #71, November 3, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #71, November 3, 2016

--- a/organization/_posts/2016/2016-11-10-startup.md
+++ b/organization/_posts/2016/2016-11-10-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #72, November 10, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #72, November 10, 2016

--- a/organization/_posts/2016/2016-11-17-startup.md
+++ b/organization/_posts/2016/2016-11-17-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #73, November 17, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #73, November 17, 2016

--- a/organization/_posts/2016/2016-12-01-startup.md
+++ b/organization/_posts/2016/2016-12-01-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #74, December 1, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #74, December 1, 2016

--- a/organization/_posts/2016/2016-12-08-startup.md
+++ b/organization/_posts/2016/2016-12-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #75, December 8, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #75, December 8, 2016

--- a/organization/_posts/2016/2016-12-15-startup.md
+++ b/organization/_posts/2016/2016-12-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #76, December 15, 2016"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #76, December 15, 2016

--- a/organization/_posts/2017/2017-01-12-startup.md
+++ b/organization/_posts/2017/2017-01-12-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #77, January 12, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #77, January 12, 2017

--- a/organization/_posts/2017/2017-01-19-startup.md
+++ b/organization/_posts/2017/2017-01-19-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #78, January 19, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #78, January 19, 2017

--- a/organization/_posts/2017/2017-02-02-startup.md
+++ b/organization/_posts/2017/2017-02-02-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #79, February 2, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #79, February 2, 2017

--- a/organization/_posts/2017/2017-02-09-startup.md
+++ b/organization/_posts/2017/2017-02-09-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #80, February 9, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #80, February 9, 2017

--- a/organization/_posts/2017/2017-02-16-startup.md
+++ b/organization/_posts/2017/2017-02-16-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #81, February 16, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #81, February 16, 2017

--- a/organization/_posts/2017/2017-02-21-licensing.md
+++ b/organization/_posts/2017/2017-02-21-licensing.md
@@ -1,6 +1,6 @@
 ---
 title: "Licensing WG Meeting, February 21, 2017"
-layout: default
+layout: meetings
 ---
 
 # Licensing Working Group Meeting, February 21, 2017

--- a/organization/_posts/2017/2017-02-23-startup.md
+++ b/organization/_posts/2017/2017-02-23-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #82, February 23, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #82, February 23, 2017

--- a/organization/_posts/2017/2017-03-02-startup.md
+++ b/organization/_posts/2017/2017-03-02-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #83, March 2, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #83, March 2, 2017

--- a/organization/_posts/2017/2017-03-09-startup.md
+++ b/organization/_posts/2017/2017-03-09-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #84, March 9, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #84, March 9, 2017

--- a/organization/_posts/2017/2017-03-16-startup.md
+++ b/organization/_posts/2017/2017-03-16-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #85, March 16, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #85, March 16, 2017

--- a/organization/_posts/2017/2017-03-23-startup.md
+++ b/organization/_posts/2017/2017-03-23-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #86, March 23, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #86, March 23, 2017

--- a/organization/_posts/2017/2017-03-30-startup.md
+++ b/organization/_posts/2017/2017-03-30-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #87, March 30, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #87, March 30, 2017

--- a/organization/_posts/2017/2017-04-06-startup.md
+++ b/organization/_posts/2017/2017-04-06-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #88, April 6, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #88, April 6, 2017

--- a/organization/_posts/2017/2017-04-20-startup.md
+++ b/organization/_posts/2017/2017-04-20-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #89, April 20, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #89, April 20, 2017

--- a/organization/_posts/2017/2017-04-27-startup.md
+++ b/organization/_posts/2017/2017-04-27-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #90, April 27, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #90, April 27, 2017

--- a/organization/_posts/2017/2017-05-04-startup.md
+++ b/organization/_posts/2017/2017-05-04-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #91, May 4, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #91, May 4, 2017

--- a/organization/_posts/2017/2017-05-11-startup.md
+++ b/organization/_posts/2017/2017-05-11-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #92, May 11, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #92, May 11, 2017

--- a/organization/_posts/2017/2017-05-18-startup.md
+++ b/organization/_posts/2017/2017-05-18-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #93, May 18 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #93, May 18 2017

--- a/organization/_posts/2017/2017-06-01-startup.md
+++ b/organization/_posts/2017/2017-06-01-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #94, June 1, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #94, June 1, 2017

--- a/organization/_posts/2017/2017-06-08-startup.md
+++ b/organization/_posts/2017/2017-06-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #95, June 8, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #95, June 8, 2017

--- a/organization/_posts/2017/2017-06-15-startup.md
+++ b/organization/_posts/2017/2017-06-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #96, June 15, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #96, June 15, 2017

--- a/organization/_posts/2017/2017-06-22-startup.md
+++ b/organization/_posts/2017/2017-06-22-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #97, June 22, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #97, June 22, 2017

--- a/organization/_posts/2017/2017-07-06-startup.md
+++ b/organization/_posts/2017/2017-07-06-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #98, July 6, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #98, July 6, 2017

--- a/organization/_posts/2017/2017-07-13-startup.md
+++ b/organization/_posts/2017/2017-07-13-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #99, July 13, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #99, July 13, 2017

--- a/organization/_posts/2017/2017-07-20-startup.md
+++ b/organization/_posts/2017/2017-07-20-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #100, July 20, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #100, July 20, 2017

--- a/organization/_posts/2017/2017-07-27-startup.md
+++ b/organization/_posts/2017/2017-07-27-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #101, July 27, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #101, July 27, 2017

--- a/organization/_posts/2017/2017-08-03-startup.md
+++ b/organization/_posts/2017/2017-08-03-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #102, August 3, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #102, August 3, 2017

--- a/organization/_posts/2017/2017-08-10-startup.md
+++ b/organization/_posts/2017/2017-08-10-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #103, August 10, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #103, August 10, 2017

--- a/organization/_posts/2017/2017-08-17-startup.md
+++ b/organization/_posts/2017/2017-08-17-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #104, August 17, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #104, August 17, 2017

--- a/organization/_posts/2017/2017-08-24-startup.md
+++ b/organization/_posts/2017/2017-08-24-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #105, August 24, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #105, August 24, 2017

--- a/organization/_posts/2017/2017-08-31-startup.md
+++ b/organization/_posts/2017/2017-08-31-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #106, August 31, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #106, August 30, 2017

--- a/organization/_posts/2017/2017-09-07-startup.md
+++ b/organization/_posts/2017/2017-09-07-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #107, September 7, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #107, September 7, 2017

--- a/organization/_posts/2017/2017-09-14-startup.md
+++ b/organization/_posts/2017/2017-09-14-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #108, September 14, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #108, September 14, 2017

--- a/organization/_posts/2017/2017-09-21-startup.md
+++ b/organization/_posts/2017/2017-09-21-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #109, September 21, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #109, September 21, 2017

--- a/organization/_posts/2017/2017-09-28-startup.md
+++ b/organization/_posts/2017/2017-09-28-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #110, September 28, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #110, September 28, 2017

--- a/organization/_posts/2017/2017-10-05-startup.md
+++ b/organization/_posts/2017/2017-10-05-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #111, October 5, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #111, October 5, 2017

--- a/organization/_posts/2017/2017-10-12-startup.md
+++ b/organization/_posts/2017/2017-10-12-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #112, October 12, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #112, October 12, 2017

--- a/organization/_posts/2017/2017-10-18-packaging.md
+++ b/organization/_posts/2017/2017-10-18-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #12, October 18, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Packaging Group Meeting #12, October 18, 2017

--- a/organization/_posts/2017/2017-10-18-startup.md
+++ b/organization/_posts/2017/2017-10-18-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #113, October 19, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #113, October 19, 2017

--- a/organization/_posts/2017/2017-10-26-startup.md
+++ b/organization/_posts/2017/2017-10-26-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #114, October 26, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #114, October 26, 2017

--- a/organization/_posts/2017/2017-11-01-packaging.md
+++ b/organization/_posts/2017/2017-11-01-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #13, November 1, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Packaging Group Meeting #13, November 1, 2017

--- a/organization/_posts/2017/2017-11-02-startup.md
+++ b/organization/_posts/2017/2017-11-02-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #115, November 2, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #115, November 2, 2017

--- a/organization/_posts/2017/2017-11-09-startup.md
+++ b/organization/_posts/2017/2017-11-09-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #116, November 9, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #116, November 9, 2017

--- a/organization/_posts/2017/2017-11-15-packaging.md
+++ b/organization/_posts/2017/2017-11-15-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #14, November 15, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Packaging Group Meeting #14, November 15, 2017

--- a/organization/_posts/2017/2017-11-16-startup.md
+++ b/organization/_posts/2017/2017-11-16-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #117, November 16, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #117, November 16, 2017

--- a/organization/_posts/2017/2017-11-29-packaging.md
+++ b/organization/_posts/2017/2017-11-29-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #15, November 29, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Packaging Group Meeting #15, November 29, 2017

--- a/organization/_posts/2017/2017-11-30-startup.md
+++ b/organization/_posts/2017/2017-11-30-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #118, November 30, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #118, November 30, 2017

--- a/organization/_posts/2017/2017-12-07-startup.md
+++ b/organization/_posts/2017/2017-12-07-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #119, December 7, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #119, December 7, 2017

--- a/organization/_posts/2017/2017-12-13-packaging.md
+++ b/organization/_posts/2017/2017-12-13-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #16, December 13, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Packaging Group Meeting #16, December 13, 2017

--- a/organization/_posts/2017/2017-12-14-startup.md
+++ b/organization/_posts/2017/2017-12-14-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #120, December 14, 2017"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #120, December 14, 2017

--- a/organization/_posts/2018/2018-01-11-startup.md
+++ b/organization/_posts/2018/2018-01-11-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #121, January 11, 2018"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #121, January 11, 2018

--- a/organization/_posts/2018/2018-01-18-startup.md
+++ b/organization/_posts/2018/2018-01-18-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #122, January 18, 2018"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #122, January 18, 2018

--- a/organization/_posts/2018/2018-01-24-packaging.md
+++ b/organization/_posts/2018/2018-01-24-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #17, January 24, 2018"
-layout: default
+layout: meetings
 ---
 
 # HSF Packaging Group Meeting #17, January 24, 2018

--- a/organization/_posts/2018/2018-01-25-startup.md
+++ b/organization/_posts/2018/2018-01-25-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #123, January 25, 2018"
-layout: default
+layout: meetings
 ---
 
 # HSF Weekly Meeting #123, January 25, 2018

--- a/organization/_posts/2018/2018-02-01-startup.md
+++ b/organization/_posts/2018/2018-02-01-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #124, 1 February, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-02-07-packaging.md
+++ b/organization/_posts/2018/2018-02-07-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #18, February 7, 2018"
-layout: default
+layout: meetings
 ---
 
 # HSF Packaging Group Meeting #18, February 7, 2018

--- a/organization/_posts/2018/2018-02-08-startup.md
+++ b/organization/_posts/2018/2018-02-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #125, 8 February, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-02-15-startup.md
+++ b/organization/_posts/2018/2018-02-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #126, 15 February, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-02-21-packaging.md
+++ b/organization/_posts/2018/2018-02-21-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #19, February 21, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-02-22-startup.md
+++ b/organization/_posts/2018/2018-02-22-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #127, 22 February, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-03-01-startup.md
+++ b/organization/_posts/2018/2018-03-01-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #128, 1 March, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-03-07-packaging.md
+++ b/organization/_posts/2018/2018-03-07-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #20, March 7, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-03-08-startup.md
+++ b/organization/_posts/2018/2018-03-08-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #129, 8 March, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-03-15-startup.md
+++ b/organization/_posts/2018/2018-03-15-startup.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #130, 15 March, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-03-21-packaging.md
+++ b/organization/_posts/2018/2018-03-21-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #21, March 21, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-03-22-coordination.md
+++ b/organization/_posts/2018/2018-03-22-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #131, 22 March, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-04-04-packaging.md
+++ b/organization/_posts/2018/2018-04-04-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #22, April 4, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-04-05-coordination.md
+++ b/organization/_posts/2018/2018-04-05-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #132, 5 April, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-04-12-coordination.md
+++ b/organization/_posts/2018/2018-04-12-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #133, 12 April, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-04-19-coordination.md
+++ b/organization/_posts/2018/2018-04-19-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #134, 19 April, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-04-23-training.md
+++ b/organization/_posts/2018/2018-04-23-training.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Training and Careers Working Group Meeting, 23 April, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-05-02-packaging.md
+++ b/organization/_posts/2018/2018-05-02-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #23, May 2, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-05-03-coordination.md
+++ b/organization/_posts/2018/2018-05-03-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #135, 4 May, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-05-09-licensing.md
+++ b/organization/_posts/2018/2018-05-09-licensing.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Licensing Meeting, 9 May, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-05-16-packaging.md
+++ b/organization/_posts/2018/2018-05-16-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #24, May 16, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-05-17-coordination.md
+++ b/organization/_posts/2018/2018-05-17-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #136, 17 May, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-05-24-coordination.md
+++ b/organization/_posts/2018/2018-05-24-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #137, 24 May, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-05-31-coordination.md
+++ b/organization/_posts/2018/2018-05-31-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #138, 31 May, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-06-06-softwareforum.md
+++ b/organization/_posts/2018/2018-06-06-softwareforum.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Software Forum, 6 June, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-06-07-coordination.md
+++ b/organization/_posts/2018/2018-06-07-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #139, 7 June, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-06-13-packaging.md
+++ b/organization/_posts/2018/2018-06-13-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Packaging Group Meeting #25, June 13, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-06-14-software-tools.md
+++ b/organization/_posts/2018/2018-06-14-software-tools.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Software Tools Meeting, 14 June, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-06-21-coordination.md
+++ b/organization/_posts/2018/2018-06-21-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #140, 21 June, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-06-28-coordination.md
+++ b/organization/_posts/2018/2018-06-28-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #141, 28 June, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-07-18-softwareforum.md
+++ b/organization/_posts/2018/2018-07-18-softwareforum.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Software Forum on Vectorisation Tools, 18 July, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}

--- a/organization/_posts/2018/2018-07-19-coordination.md
+++ b/organization/_posts/2018/2018-07-19-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: "HSF Weekly Meeting #142, 19 July, 2018"
-layout: default
+layout: meetings
 ---
 
 # {{page.title}}


### PR DESCRIPTION
In order to fulfill request #332 to ease navigation of the website, we added links towards the previous and following meeting minutes on the top and bottom of each meeting minute page.

This is done via a layout, and is therefore created automatically. All meetings are now using the new 'meetings' layout, instead of 'default'.

In this new layout, the code checks for existing posts before and after the current one, using jekyll's `page.next` and `page.previous` variables.  If found, it creates text with the title of the post (`page.title`), linking to the url of said post (`page.url`). However, when searching for existing posts, jekyll searches the entire repository, instead of limiting itself to the `organization/_posts` folder. Therefore, we create a plugin (along with a new, `_plugin` folder) that generates new "page commands" that are constrained to a specific folder.

Finally, to format these links, we defined new commands in the css file, that allow us to align text on the same line to the left and right side of the page.