### PR TITLE
Software Forum announce and better navigation

### DIFF
--- a/_includes/fwd_back_link.ext
+++ b/_includes/fwd_back_link.ext
@@ -1,0 +1,15 @@
+<div class="PageNavigation">
+
+  <!-- Note that page sorting is reverse time ordered, so "next" refers to the previous
+       meeting in time and "previous" to the next one -->
+  {% if page.previous %}
+   <p class="alignleft"><a href="{{ page.previous.url }}">&nbsp;&#8592; {{ page.previous.title }}</a></p>
+  {% endif %}
+
+  {% if page.next %}
+    <p class="alignright"><a href="{{ page.next.url }}">{{ page.next.title }} &#8594;&nbsp;</a></p>
+  {% endif %}
+
+</div>
+
+<div style="clear: both;"></div>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -2,6 +2,10 @@
 layout: default
 ---
 
+{% include fwd_back_link.ext %}
+
+<hr>
+
 <div class="blog-header">
   <h1 class="blog-title">{{ page.title }}</h1>
   <p class="blog-post-meta">{{ page.date | date_to_string }} by <a href="{{ page.url }}">{{ page.author }}</a></p>

--- a/_layouts/meetings.html
+++ b/_layouts/meetings.html
@@ -17,22 +17,7 @@
 
 <div class="container">
 
-
-<div class="PageNavigation">
-
-  <!-- Note that page sorting is reverse time ordered, so "next" refers to the previous
-       meeting in time and "previous" to the next one -->
-  {% if page.previous %}
-   <p class="alignleft"><a href="{{ page.previous.url }}">&nbsp;&#8592; {{ page.previous.title }}</a></p>
-  {% endif %}
-
-  {% if page.next %}
-    <p class="alignright"><a href="{{ page.next.url }}">{{ page.next.title }} &#8594;&nbsp;</a></p>
-  {% endif %}
-
-</div>
-
-<div style="clear: both;"></div>
+{% include fwd_back_link.ext %}
 
 <hr>
 
@@ -40,22 +25,8 @@
 
 <hr>
 
+{% include fwd_back_link.ext %}
 
-<div class="PageNavigation">
-
-  <!-- Note that page sorting is reverse time ordered, so "next" refers to the previous
-       meeting in time and "previous" to the next one -->
-  {% if page.previous %}
-   <p class="alignleft"><a href="{{ page.previous.url }}">&nbsp;&#8592; {{ page.previous.title }}</a></p>
-  {% endif %}
-
-  {% if page.next %}
-    <p class="alignright"><a href="{{ page.next.url }}">{{ page.next.title }} &#8594;&nbsp;</a></p>
-  {% endif %}
-
-  </div>
-
-  <div style="clear: both;"></div>
 <br><br>
 <div class="footer fixed-bottom">
 Thanks to <a href="https://pages.github.com/">GitHub Pages</a>, <a href="http://jekyllrb.com/">Jekyll</a> and <a href="http://getbootstrap.com/">Bootstrap</a>

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -2,6 +2,10 @@
 layout: default
 ---
 
+{% include fwd_back_link.ext %}
+
+<hr>
+
 <div class="blog-header">
   <h1 class="blog-title">{{ page.title }}</h1>
   <p class="blog-post-meta">{{ page.date | date_to_string }} by <a href="{{ page.url }}">{{ page.author }}</a></p>

--- a/announcements/_posts/2018-09-26-software-dev-heptrkx.md
+++ b/announcements/_posts/2018-09-26-software-dev-heptrkx.md
@@ -1,0 +1,9 @@
+---
+title:  Software Forum - HEP.TrkX, 26 September 2018
+author: Graeme Stewart
+layout: newsletter
+symbol: glyphicon-calendar
+link: https://indico.cern.ch/event/745416/
+until: 2018-09-26
+---
+HSF Software Forum Meeting


### PR DESCRIPTION
Announce next software forum.

Improve navigation:
- As the events and newsletter templates are used in the general list of navigated posts it's important to maintain the forward and backward links on them so that users don't lose navigation on these pages.
- The navigation code is factorised out to an "include" and then pulled in to the correct places of the event, meeting and newsletter layouts.
