### PR TITLE
Creation of page for PyHEP activities and info

### DIFF
--- a/_workinggroups/pyhep.md
+++ b/_workinggroups/pyhep.md
@@ -1,14 +1,36 @@
 ---
-title: PyHEP Workshops
-author: "Eduardo Rodrigues"
-layout: default
+title: PyHEP - "Python in HEP"
+layout: plain
+redirect_from:
+  - /activities/pyhep.html
 ---
 
-# PyHEP "Python in HEP" Series of Workshops
+The PyHEP working group brings together a community of developers and users of Python in Particle Physics, with the aim of improving
+the sharing of knowledge and expertise. It embraces the broad community, from HEP to the Astroparticle and Intensity Frontier communities.
+
+The group is currently coordinated by Chris Tunnell (Rice U.), Eduardo Rodrigues (U. Cincinnati) and Graeme Stewart (CERN).
+All coordinators can be reached via <hsf-pyhep-organisation@googlegroups.com>.
+
+# Getting Involved
+
+Everyone is welcome to join the community and participate by means of the following:
+
+[Gitter channel PyHEP](https://gitter.im/HSF/PyHEP){:target="_pyhep_gitter_channel} for any informal exchanges.
+
+[GitHub repository of resources](https://github.com/hsf-training/PyHEP-resources){:target="_pyhep_resources_repo"}
+- Python libraries of interest to Particle Physics.
+
+# PyHEP Series of Workshops
 
 The **PyHEP workshops** are a new series of workshops initiated and supported by the HSF
 with the aim to provide an environment to discuss and promote the usage of Python in the HEP community at large.
 
+{:.table .table-hover .table-condensed .table-striped}
+| *Workshop* | *Location*          | *Date*               | *Agenda link*                                                                 |
+| ---------- | ------------------- | ---------------------| ----------------------------------------------------------------------------- |
+| PyHEP 2018 | Sofia, Bulgaria     | July 7-8, 2018       | [Indico](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"}   |
+
+The advert and details on the first such workshop are given below.
 
 ## PyHEP 2018
 
@@ -43,12 +65,4 @@ Jeff Templon - Nikhef (Co-chair)
 
 The event is kindly sponsored by
 
-![Nikhef](/images/pyhep/Nikhef_logo.png){:height="90px"} ![PSF](/images/pyhep/PSF_logo.png){:height="90px"}
-
-
-## Workshops
-
-{:.table .table-hover .table-condensed .table-striped}
-| *Workshop* | *Location*          | *Date*               | *Agenda link*                                                                 |
-| ---------- | ------------------- | ---------------------| ----------------------------------------------------------------------------- |
-| PyHEP 2018 | Sofia, Bulgaria     | July 7-8, 2018       | [Indico](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"}   |
+![Nikhef](/images/pyhep/Nikhef_logo.png){:height="60px"} ![PSF](/images/pyhep/PSF_logo.png){:height="60px"}

--- a/_workinggroups/pyhep.md
+++ b/_workinggroups/pyhep.md
@@ -15,10 +15,9 @@ All coordinators can be reached via <hsf-pyhep-organisation@googlegroups.com>.
 
 Everyone is welcome to join the community and participate by means of the following:
 
-[Gitter channel PyHEP](https://gitter.im/HSF/PyHEP){:target="_pyhep_gitter_channel} for any informal exchanges.
-
-[GitHub repository of resources](https://github.com/hsf-training/PyHEP-resources){:target="_pyhep_resources_repo"}
-- Python libraries of interest to Particle Physics.
+* [Gitter channel PyHEP](https://gitter.im/HSF/PyHEP){:target="_pyhep_gitter_channel} for any informal exchanges.
+* [GitHub repository of resources](https://github.com/hsf-training/PyHEP-resources){:target="_pyhep_resources_repo"},
+  e.g., Python libraries of interest to Particle Physics.
 
 # PyHEP Series of Workshops
 
@@ -34,13 +33,13 @@ The advert and details on the first such workshop are given below.
 
 ## PyHEP 2018
 
-The first workshop, **PyHEP 2018**, will be held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/). It will focus on a review of where and how Python is used in our community, and what the future will hold.
-The workshop will be a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There will be ample time for discussion.
+The first workshop, **PyHEP 2018**, was held as a pre-CHEP event in Sofia, Bulgaria, on 7-8 July 2018, just before the start of the [CHEP 2018 conference](http://chep2018.org/). It focused on a review of where and how Python is used in our community, and what the future will hold.
+The workshop was a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There was ample time for discussion.
 
 A keynote presentation on [JupyterLab](http://jupyterlab.readthedocs.io/){:target="_pyhep2018_jupyterlab"}
-will be given by [Vidar Tonaas Fauske](https://www.simula.no/people/vidar){:target="_pyhep2018_vidar"}.
+was given by [Vidar Tonaas Fauske](https://www.simula.no/people/vidar){:target="_pyhep2018_vidar"}.
 
-The [agenda](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"} will be composed of plenary sessions dedicated to the following topics:
+The [agenda](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"} was composed of plenary sessions dedicated to the following topics:
 
 1. Historical perspective and overview
 2. PyROOT and Python bindings
@@ -50,10 +49,10 @@ The [agenda](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"} 
 6. Python 2 and 3
 7. Open discussion on education and training
 
-There won't be any training sessions or hackathons in this first workshop,
-but some level of tuition will come in small bites in the various presentations,
-which will try and be educative, not just informative, with well-defined examples relevant to the topics under discussion.
-One of the goals of this PyHEP workshop will be to identify training workshops or hackathons the community would like to have in the future.
+There were no training sessions nor hackathons in this first workshop,
+but some level of tuition came in small bites in the various presentations,
+which tried to be educative, not just informative, with well-defined examples relevant to the topics under discussion.
+One of the goals of this PyHEP workshop was the identification of training workshops or hackathons the community would like to have in the future.
 
 ### Organising Committee
 
@@ -63,6 +62,6 @@ Jeff Templon - Nikhef (Co-chair)
 
 ### Sponsors
 
-The event is kindly sponsored by
+The event was kindly sponsored by
 
 ![Nikhef](/images/pyhep/Nikhef_logo.png){:height="60px"} ![PSF](/images/pyhep/PSF_logo.png){:height="60px"}


### PR DESCRIPTION
General page under "working groups" for all PyHEP activities:

- Not just the workshop in Sofia.
- Gitter channel.
- GitHub repo on resources.