### PR TITLE
Add links from forum page back to WGs and Activities

### DIFF
--- a/_activities/licensing.md
+++ b/_activities/licensing.md
@@ -4,35 +4,41 @@ layout: plain
 redirect_from: /workinggroups/2015/11/04/licensing.html
 ---
 
-Many of the projects interested in participating to the HSF mentioned licensing 
-as in important topic where the HSF could help. Many projects in our community 
-don't have an explicit license, some have started with one license but are 
+Many of the projects interested in participating to the HSF mentioned licensing
+as in important topic where the HSF could help. Many projects in our community
+don't have an explicit license, some have started with one license but are
 facing problems as the project is growing and incorporating new partners.
 
-This is recognized as a complex issue where the collaboration helps not to 
-forget one aspect and to make decisions compatible with our international 
-projects. With contributors from many different countries involved, we have to 
+This is recognized as a complex issue where the collaboration helps not to
+forget one aspect and to make decisions compatible with our international
+projects. With contributors from many different countries involved, we have to
 deal with different laws and policies.
 
-Despite the HSF is only about open-source software, there are several licensing 
-options with different advantages and drawbacks and not all of these options 
-are compatible. This is a potential problem for the HSF as its goal is to 
-create a software ecosystem where all packages can be combined to address the 
+Despite the HSF is only about open-source software, there are several licensing
+options with different advantages and drawbacks and not all of these options
+are compatible. This is a potential problem for the HSF as its goal is to
+create a software ecosystem where all packages can be combined to address the
 computing needs of our community.
 
-In Spring 2015, A working group has been formed with people from the community 
-who had already some experiences with licensing issues. This working group, as 
-any in the HSF, is open to new participants and contributions. Most 
+In Spring 2015, A working group has been formed with people from the community
+who had already some experiences with licensing issues. This working group, as
+any in the HSF, is open to new participants and contributions. Most
 discussions so far took place in the HSF Technical Forum
 (<hsf-forum@googlegroups.com>).
 
-A first [Technical Note](/notes/HSF-TN-2016-01.pdf) 
-was released in February 2016, 
-discussing the main issues related to open-source software licensing and 
-proposing some licensing recommendations for HSF projects which don't have 
-already a well established license. This Technical Note reflects the consensus at the 
+A first [Technical Note](/notes/HSF-TN-2016-01.pdf)
+was released in February 2016,
+discussing the main issues related to open-source software licensing and
+proposing some licensing recommendations for HSF projects which don't have
+already a well established license. This Technical Note reflects the consensus at the
 date when it was published and is a basis for further discussions. A new version will
 be released later if needed.
+
+# Forum Mailing List
+
+The [hsf-licensing-wg](https://groups.google.com/forum/#%21forum/hsf-licensing-wg)
+is the discussion forum for the licensing working group - feel free to post
+any licensing related questions there.
 
 # Meetings
 
@@ -40,10 +46,8 @@ be released later if needed.
 
 # Resources
 
-* Software License Agreements: HSF Policy Guidelines - [Technical Note](http://hepsoftwarefoundation.org/notes/HSF-TN-2016-01.pdf), 
+* Software License Agreements: HSF Policy Guidelines - [Technical Note](http://hepsoftwarefoundation.org/notes/HSF-TN-2016-01.pdf),
   February 2016
-* Report from the Task Force on Open Source Software Licence at CERN - [Main 
-report](/assets/OSL-TF_Final_Report-Main_Volume.pdf) and 
+* Report from the Task Force on Open Source Software Licence at CERN - [Main
+report](/assets/OSL-TF_Final_Report-Main_Volume.pdf) and
 [Annexes](/assets/OSL-TF_Final_Report-Volume_of_Annexes.pdf)
-
-  

--- a/forums.md
+++ b/forums.md
@@ -9,7 +9,7 @@ layout: default
 Discussions and activities in the HEP Software Foundation rely on several mailing lists and forums, some of them for general discussions, others for topical ones. All these forums are open to anybody interested and archives are publically available but they generally require that you register in order to participate.
 
 *Most of these forums are hosted by Google Groups. To register to them with your preferred email, simply send a mail to
-`forum_name+subscribe@googlegroups.com` (with `forum_name` replaced by the actual name, e.g. `hsf-tech`): subject and contents 
+`forum_name+subscribe@googlegroups.com` (with `forum_name` replaced by the actual name, e.g. `hsf-tech`): subject and contents
 are ignored and can be empty. If you want to register with your Google account, you can also use the web page associated with the forum
 (see below).*
 
@@ -19,7 +19,7 @@ are ignored and can be empty. If you want to register with your Google account, 
 
 ### General Information about HSF: hsf-forum@googlegroups.com
 
-The [hsf-forum](http://groups.google.com/d/forum/hsf-forum) is the general announcement and discussion forum for the HSF. Our meeting announcements are posted here, as are meeting minutes. The forum is intended for discussion, not just announcements. And everybody interested into the HSF, even though it is only for specific topic, is encourage to register to this forum to get all announcements. 
+The [hsf-forum](http://groups.google.com/d/forum/hsf-forum) is the general announcement and discussion forum for the HSF. Our meeting announcements are posted here, as are meeting minutes. The forum is intended for discussion, not just announcements. And everybody interested into the HSF, even though it is only for specific topic, is encourage to register to this forum to get all announcements.
 
 ### HSF Technical Forum: hsf-tech-forum@googlegroups.com
 
@@ -30,14 +30,22 @@ The [hsf-tech-forum](https://groups.google.com/forum/#%21forum/hsf-tech-forum) i
 This is not strictly an HSF mailing list. The [HEP S&C community mailing list](http://groups.google.com/d/forum/hep-sw-comp) is intended for occasional HEP software and computing community mailings. Everyone involved or interested in HEP S&C is encouraged to sign up to this list. It will be used for occasional mailings of community wide interest, such as announcements of HEP S&C conferences, workshops and schools not strictly related to the HSF.
 
 
-## Dedicated Activity Forums
+## Dedicated Activities and Working Groups
 -----
 
-### HSF Training Activities: hsf-training-wg
-The [hsf-training-wg](https://groups.google.com/forum/#%21forum/hsf-training-wg) is the discussion forum for the training working group.
+Each of the HSF Working groups maintains a dedicated page where contact
+information for that group can be found:
 
-### HSF Packaging WG: hsf-packaging-wg
-The [hsf-packaging-wg](https://groups.google.com/forum/#%21forum/hsf-packaging-wg) is the discussion forum for the packaging working group.
+<ul class="list">
+{% for wg in site.workinggroups %}
+  <li> <a href="{{ wg.url }}">{{ wg.title }}</a></li>
+{% endfor %}
+</ul>
 
-### HSF Licensing WG: hsf-licensing-wg
-The [hsf-licensing-wg](https://groups.google.com/forum/#%21forum/hsf-licensing-wg) is the discussion forum for the licensing working group.
+And for other HSF activities there are also dedicated pages:
+
+<ul class="list">
+{% for activity in site.activities %}
+  <li> <a href="{{ activity.url }}">{{ activity.title }}</a></li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
As working groups are making sure they have contact and "get involved" information in their WG pages I re-jigged the "Mailing Lists and Forums" page to cross link to WG and Activity pages.

I made sure the licensing forum was linked from its page.