### PR TITLE
[GSoC] Update list of mentors

### DIFF
--- a/_gsocorgs/2019/unl.md
+++ b/_gsocorgs/2019/unl.md
@@ -7,3 +7,5 @@ logo: unl.png
 description: |
     The University of Nebraska–Lincoln, often referred to as Nebraska, UNL or NU, is a public research university in the city of Lincoln, in the state of Nebraska in the Midwestern United States. It is the state's oldest university, and the largest in the University of Nebraska system.
 ---
+
+{% include gsoc_proposal.ext %}

--- a/gsoc/2019/mentors.md
+++ b/gsoc/2019/mentors.md
@@ -5,4 +5,9 @@ layout: plain
 
 ## Full Mentor List (Name, Email, Org)
 
+* Ulrik Egede [ulrik.egede@monash.edu](mailto:ulrik.egede@monash.edu) Monash University
 * Julien Peloton [peloton@lal.in2p3.fr](mailto:peloton@lal.in2p3.fr) LAL
+* Alex Richards [a.richards@imperial.ac.uk](mailto:a.richards@imperial.ac.uk) Imperial College London
+* Oksana Shadura [oksana.shadura@cern.ch](mailto:oksana.shadura@cern.ch) University of Nebraska
+* Mark Smith [mark.smith1@imperial.ac.uk](mailto:mark.smith1@imperial.ac.uk) Imperial College London
+* Yuka Takahashi [yuka@cern.ch](mailto:yuka@cern.ch) CERN

--- a/gsoc/guideline.md
+++ b/gsoc/guideline.md
@@ -19,7 +19,7 @@ layout: default
       * It can be copied from last year if still valid
       * Add a logo to [images](https://github.com/HSF/hsf.github.io/tree/master/images)
    * update the list of mentors (`gsoc/YEAR/mentors.md`)
-      * Follow this format: `[YOUR@MAIL](mailto:YOUR@MAIL>) YOURORGANIZATION`
+      * Follow this format: `YOURNAME [YOUR@MAIL](mailto:YOUR@MAIL) YOURORGANIZATION`
    * make a pull request
 
 **Every proposal must be attached to an organization (e.g. CERN, Fermilab...) and to a project (e.g. ROOT, GeantV...).** If you add your own proposal yourself, be sure add the appropriate `organization` and `project` attributes (not case sensitive) in the *front-matter* section of the proposal. See next sections if you need to add a new organization or project but if you use an existing project and organization for your proposal you don't have to do anything else that what was described above.


### PR DESCRIPTION
Also fix a couple of bugs:

- Missing `include` on UNL's description
- Wrong format in the guideline to add new mentors