### PR TITLE
Small update to contact group convenors more easily

### DIFF
--- a/_workinggroups/packaging.md
+++ b/_workinggroups/packaging.md
@@ -14,9 +14,12 @@ The group is currently convened by Ben Morgan (Warwick) and Graeme Stewart (CERN
 
 Everyone is welcome to participate and contribute on the forum and to the ongoing meetings:
 
-[Packaging Group Discussion Forum](https://groups.google.com/forum/#!forum/hsf-packaging-wg){:target="_hsf_packaging_forum}
+* [Packaging Group Discussion Forum](https://groups.google.com/forum/#!forum/hsf-packaging-wg){:target="_hsf_packaging_forum}
 
-[Packaging Group Meetings Indico](https://indico.cern.ch/category/7975/){:target="_hsf_packaging_indico"}
+* [Contact the group convenors](mailto:ben.morgan@warwick.ac.uk,graeme.andrew.stewart@cern.ch)
+  (Ben and Graeme)
+
+* [Packaging Group Meetings Indico](https://indico.cern.ch/category/7975/){:target="_hsf_packaging_indico"}
 
 # Goals
 


### PR DESCRIPTION
Just a small update to the getting involved links (bullets) and add convenor contacts.