### PR TITLE
Fix gsoc_project.ext include

### DIFF
--- a/_includes/gsoc_project.ext
+++ b/_includes/gsoc_project.ext
@@ -14,7 +14,7 @@ Project names are not case sensitive.
 {% comment %}
 Use the project name as the page title if none has been specified (they are typically identical)
 {% endcomment %}
-{% capture current_title %}{% if page.title == blank %}{{ page.project }}{% else %}{{ page.title }}{% endif %}{% endcapture %}
+{% capture current_title %}{% if page.title contains "Project_" %}{{ page.project }}{% else %}{{ page.title }}{% endif %}{% endcapture %}
 
 # GSoC {{ year }} Projects Related To {{ current_title }}
 


### PR DESCRIPTION
This include shows a header including either page.title if defined or page.project. The current condition `page.title == blank` is never `True` even if a proposal has not defined that attribute. This variable seems to be set by default to "Project_<PROJECTNAME>". This PR modifies the condition to print the content of `page.title` if "Project_" is not part of `page.title` else `page.project` is shown.