### PR TITLE
Fix failing url by adding https

### DIFF
--- a/_gsocprojects/2019/project_AstroLab.md
+++ b/_gsocprojects/2019/project_AstroLab.md
@@ -3,9 +3,9 @@ project: AstroLab
 layout: default
 logo: Icone_AstroLab_sans_fond.png
 description: |
-  [AstroLab Software](https://astrolabsoftware.github.io/) is a project from [LAL](www.lal.in2p3.fr) aiming at providing advanced software tools to overcome modern science challenges faced by research groups, and allow research communities to more fully exploit the big data ecosystem tools.
+  [AstroLab Software](https://astrolabsoftware.github.io/) is a project from [LAL](https://www.lal.in2p3.fr) aiming at providing advanced software tools to overcome modern science challenges faced by research groups, and allow research communities to more fully exploit the big data ecosystem tools.
 summary: |
-  [AstroLab Software](https://astrolabsoftware.github.io/) is a project from [LAL](www.lal.in2p3.fr) aiming at providing advanced software tools to overcome modern science challenges faced by research groups, and allow research communities to more fully exploit the big data ecosystem tools.
+  [AstroLab Software](https://astrolabsoftware.github.io/) is a project from [LAL](https://www.lal.in2p3.fr) aiming at providing advanced software tools to overcome modern science challenges faced by research groups, and allow research communities to more fully exploit the big data ecosystem tools.
 ---
 
 {% include gsoc_project.ext %}


### PR DESCRIPTION
`html-proofer` seems to fail if a link is not marked as `https`  or `http`