### PR TITLE
Force events agenda to be in English

### DIFF
--- a/future-events.md
+++ b/future-events.md
@@ -3,5 +3,4 @@ title: Future HSF and Community Events
 layout: plain
 ---
 
-<iframe src="https://calendar.google.com/calendar/embed?mode=AGENDA&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&amp;color=%23865A5A&amp;ctz=Europe%2FZurich" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-
+<iframe src="https://calendar.google.com/calendar/b/1/embed?height=600&amp;wkst=2&amp;hl=en&amp;bgcolor=%23FFFFFF&amp;src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&amp;color=%23865A5A&amp;ctz=Europe%2FZurich" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
Small improvement to the events frame generated by Google, making the language English and avoiding weird localisation issues (e.g., at CERN you get German by default).