### PR TITLE
RecoTrigger WG: add link to meeting agendas

### DIFF
--- a/_workinggroups/recotrigger.md
+++ b/_workinggroups/recotrigger.md
@@ -31,6 +31,7 @@ follow our mailing list on google groups [hsf-recotrigger](https://groups.google
 
 ## Group activities
 
+* Reconstruction+Trigger group meetings: [agendas](https://indico.cern.ch/category/10917/) 
 * Reconstruction+Trigger sessions at HOW2019 JLab include discussions on real-time analysis, reconstruction on accelerators, and more: [agenda](https://indico.cern.ch/event/759388/timetable/#20190320.detailed).
 
 ## Details


### PR DESCRIPTION
Add missing link in WG page.