### PR TITLE
Made the list of schools into an include.

### DIFF
--- a/Schools/_posts/2019-06-06-art-of-data.md
+++ b/Schools/_posts/2019-06-06-art-of-data.md
@@ -1,8 +1,8 @@
 ---
 title: Gridka - The art of Data
 source: https://indico.scc.kit.edu/event/460/
-date: 2019-07-26
-end_date: 2019-07-30
+date: 2019-08-26
+end_date: 2019-08-30
 author: Guillermo Fidalgo
 layout: event
 categories: Schools

--- a/Schools/_posts/2019-10-28-1st-Pan-European-Advanced-School-on-Statistics-in-HEP.md
+++ b/Schools/_posts/2019-10-28-1st-Pan-European-Advanced-School-on-Statistics-in-HEP.md
@@ -1,0 +1,10 @@
+---
+title:  1st Pan-European Advanced School on Statistics in HEP
+source: https://indico.desy.de/indico/event/22731/
+date: 2019-10-28
+end_date: 2019-11-01
+author: Guillermo Fidalgo
+layout: event
+categories: Schools
+---
+[1st Pan-European Advanced School on Statistics in HEP](https://indico.desy.de/indico/event/22731/)

--- a/Schools/_posts/2020-01-13-ISOTDAQ.md
+++ b/Schools/_posts/2020-01-13-ISOTDAQ.md
@@ -1,0 +1,10 @@
+---
+title:  11th International School of Trigger and Data Acquisition
+source: https://indico.cern.ch/event/828931/
+date: 2020-01-13
+end_date: 2020-01-22
+author: Guillermo Fidalgo
+layout: event
+categories: Schools
+---
+[11th International School of Trigger and Data Acquisition](https://indico.cern.ch/event/828931/)

--- a/Schools/events.md
+++ b/Schools/events.md
@@ -2,17 +2,5 @@
 layout: plain
 title: Schools for HSF Training
 ---
-### Upcoming Training Schools
- **Warning** : Application deadlines are **before the date shown**
-{% for post in site.categories.Schools reversed %}
-{% if post.date > site.time %}
-1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
-{% endif %}
-{% endfor %}
 
-### Past Schools
-{% for post in site.categories.Schools  %}
-{% if post.date < site.time %}
-1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
-{% endif %}
-{% endfor %}
+{% include list_of_schools.md %}

--- a/_includes/list_of_schools.md
+++ b/_includes/list_of_schools.md
@@ -2,12 +2,12 @@
 
 {% assign schools = site.categories.Schools | sort:"date" %}
 
-{% capture now %}{{'now' | date: '%s' | plus: 0 %}}{% endcapture %}
+{% capture now %}{{'now' | date: '%s' | plus: 0 }}{% endcapture %}
 
 ## Current and Upcoming Training Schools
 #### **Warning** : Application deadlines are **before the date shown**
 {% for post in schools %}
-  {% capture date %}{{post.end_date | date: '%s' | plus: 0 %}}{% endcapture %}
+  {% capture date %}{{post.end_date | date: '%s' | plus: 0 }}{% endcapture %}
   {% if date > now %}
   1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
   {% endif %}

--- a/_includes/list_of_schools.md
+++ b/_includes/list_of_schools.md
@@ -1,0 +1,22 @@
+
+
+{% assign schools = site.categories.Schools | sort:"date" %}
+
+{% capture now %}{{'now' | date: '%s' | plus: 0 %}}{% endcapture %}
+
+## Current and Upcoming Training Schools
+#### **Warning** : Application deadlines are **before the date shown**
+{% for post in schools %}
+  {% capture date %}{{post.end_date | date: '%s' | plus: 0 %}}{% endcapture %}
+  {% if date > now %}
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
+  {% endif %}
+{% endfor %}
+
+## Past Schools
+{% for post in schools reversed %}
+  {% capture date %}{{post.end_date | date: '%s' | plus: 0 %}}{% endcapture %}
+  {% if date < now %}
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
+  {% endif %}
+{% endfor %}

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -33,12 +33,12 @@ Other actions in progress include:
 
 {% assign schools = site.categories.Schools | sort:"date" %}
 
-{% capture now %}{{'now' | date: '%s' | plus: 0 %}}{% endcapture %}
+{% capture now %}{{'now' | date: '%s' | plus: 0 }}{% endcapture %}
 
 ## Current and Upcoming Training Schools
 #### **Warning** : Application deadlines are **before the date shown**
 {% for post in schools %}
-  {% capture date %}{{post.end_date | date: '%s' | plus: 0 %}}{% endcapture %}
+  {% capture date %}{{post.end_date | date: '%s' | plus: 0 }}{% endcapture %}
   {% if date > now %}
   1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
   {% endif %}

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -31,8 +31,20 @@ Other actions in progress include:
 
 * A [Training section](http://hepsoftware.org/e/training) in the HSF knowledge base intended to collect training related events, organizations, software packages... **Please contribute to the knowledge base to help enriching the content**
 
-{% include list_of_schools.md %}
- For full list of Upcoming and Past Schools enter [here](/Schools/events.html)
+{% assign schools = site.categories.Schools | sort:"date" %}
+
+{% capture now %}{{'now' | date: '%s' | plus: 0 %}}{% endcapture %}
+
+## Current and Upcoming Training Schools
+#### **Warning** : Application deadlines are **before the date shown**
+{% for post in schools %}
+  {% capture date %}{{post.end_date | date: '%s' | plus: 0 %}}{% endcapture %}
+  {% if date > now %}
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
+  {% endif %}
+{% endfor %}
+
+#### For full list of Upcoming and Past Schools enter [here](/Schools/events.html)
 
 
 ## How to participate ?

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -31,25 +31,7 @@ Other actions in progress include:
 
 * A [Training section](http://hepsoftware.org/e/training) in the HSF knowledge base intended to collect training related events, organizations, software packages... **Please contribute to the knowledge base to help enriching the content**
 
-### Upcoming Training Schools
- **Warning** : Application deadlines are **before the date shown**
-{% assign future = site.categories.Schools | sort:"date" | reverse %}
-
-{% for post in future reversed limit:15 %}
-{% if post.date > site.time %}
-1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
-{% endif %}
-{% endfor %}
-
-### Past Schools
-{% assign past = site.categories.Schools | sort:"date" %}
-
-{% for post in past reversed limit:10 %}
-{% if post.date < site.time %}
-1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
-{% endif %}
-{% endfor %}
-
+{% include list_of_schools.md %}
  For full list of Upcoming and Past Schools enter [here](/Schools/events.html)
 
 


### PR DESCRIPTION
This PR is to add an include that uses the same code as before to make a list of the HSF training schools.
The major difference now is that it uses a workaround that I found to make a comparison between dates, something that jekyll seems to not like very much. 
This workaround permits the comparison of the "end date" of the school so that it can be properly classified into "Past School" or "Current or Upcoming School" instead of automatically changing the category of the school to Past School once the school has only started.