### PR TITLE
Clarify status of page

### DIFF
--- a/cwp/cwp-working-groups.md
+++ b/cwp/cwp-working-groups.md
@@ -6,6 +6,9 @@ layout: default
 
 ## Community White Paper (CWP) Working Groups
 
+> **Note Bene** The groups listed here are of *historical interest only*. If you are looking for the list
+of current HSF Working Groups then please check [this page](/what_are_WGs.html).
+
 In October, 2016, the process of forming CWP working groups began. Working groups self-organized with some help from the HEP experiment software/computing coordinators and the HSF startup team. Charges were formulated to describe the challenges in that area and questions which need to be answered to produce a roadmap for the CWP. 
 
 The working group charges and working group document should be world-visible for reading. Please


### PR DESCRIPTION
This is a historical page, so make that clear and provide a link to
the list of current working groups. At least one person reported
that a Google search sent them here, which was a confusing
place to end up...
