### PR TITLE
Coord team members: remote P. Elmer's URL

### DIFF
--- a/organization/team.md
+++ b/organization/team.md
@@ -7,7 +7,7 @@ layout: default
 
 Currently the activities within the HSF are organized by the *HSF coordination team* (formerly called the *startup team*). Following the concept of a do-ocracy active contributors to the HSF are invited to join. These are the current members of the team:
 
- * [Peter Elmer](https://phy.princeton.edu/people/g-j-peter-elmer) - Princeton University
+ * Peter Elmer - Princeton University
  * Daniel Elvira - FNAL
  * Benedikt Hegner - BNL
  * Michel Jouvin - LAL, IN2P3


### PR DESCRIPTION
Having a URL attached to a member is not a problem in itself but has the impact that the name is rendered in red, giving the impression they are the "bosses"! I think it is misleading and not inline with our way of working...

BTW, updating the coordination team page, it may be a good time to update the membership... Any suggestion?