### PR TITLE
Update to minutes page

### DIFF
--- a/organization/minutes.md
+++ b/organization/minutes.md
@@ -7,7 +7,9 @@ layout: default
 
 ## Meeting Minutes
 
-The startup team runs a regular HSF meeting (nominally, and usually, weekly) which is open to all. Meeting announcements and minutes are posted to the HSF forum google group. Activity groups also hold their own meetings, for which minutes are usually posted here.
+The coordination team runs a regular HSF meeting (nominally, and usually, weekly) which is open to all.
+Meeting announcements and minutes are posted to the HSF forum Google group.
+Activity groups also hold their own meetings, for which minutes are usually posted here.
 
 Please see [this page](/future-events.html) for future meetings and events.
 


### PR DESCRIPTION
@graeme-a-stewart, this is just a trivial update in wording, startup -> coordination, which I noticed while looking for the last minutes … The minutes number 174 are missing; I believe they correspond to the minutes taken with CodiMD ...