### PR TITLE
Add howto website link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # hsf.github.io
 HEP Software Foundation github site
+
+* Live at https://hepsoftwarefoundation.org/
+* [Website howto/documentation](https://hepsoftwarefoundation.org/howto-website.html)


### PR DESCRIPTION
Probably helpful to leave a link to the documentation in the readme (I only stumbled on it late).