### PR TITLE
Bring website instructions and descriptions up to date

### DIFF
--- a/_activities/visualization.md
+++ b/_activities/visualization.md
@@ -16,7 +16,7 @@ All are welcome to join the group and participate!
 
 Convenor: [Riccardo Maria BIANCHI](mailto:riccardo.maria.bianchi@cern.ch) (ATLAS)
 
-Mailing list: [hsf-visualization-group@googlegroups.com](mailto:hsf-visualization-group@googlegroups.com)
+Mailing list: [hsf-visualization-wg@googlegroups.com](mailto:hsf-visualization-wg@googlegroups.com)
 
 ----
 

--- a/_activities/visualization.md
+++ b/_activities/visualization.md
@@ -6,34 +6,34 @@ redirect_from:
   - /workinggroups/visualization.html
 ---
 
-The Visualisation Activity Area and Working Group (WG) gathers experts, developers, users and all people from the Particle Physics community interested in interactive data visualization and event displays. 
+The Visualisation Activity Area gathers experts, developers, users and all people from the Particle Physics community interested in interactive data visualization and event displays. 
 
-The WG has been started in October 2016 and it is convened by Riccardo Maria Bianchi (*University of Pittsburgh, US*, ATLAS Experiment). 
+The group was been started in October 2016 and it is convened by Riccardo Maria Bianchi (*University of Pittsburgh, US*, ATLAS Experiment). 
 
-All are welcome to join the WG and participate!
+All are welcome to join the group and participate!
 
 ## Contacts
 
 Convenor: [Riccardo Maria BIANCHI](mailto:riccardo.maria.bianchi@cern.ch) (ATLAS)
 
-Mailing list: [hsf-visualization-wg@googlegroups.com](mailto:hsf-visualization-wg@googlegroups.com)
+Mailing list: [hsf-visualization-group@googlegroups.com](mailto:hsf-visualization-group@googlegroups.com)
 
 ----
 
 ## Goal
 
-The goal of the WG is to discover common approaches, foster collaboration among HEP experiments and groups, plan future software development and developing common tools. 
+The goal of the group is to discover common approaches, foster collaboration among HEP experiments and groups, plan future software development and developing common tools. 
 
 ----
 
-## Description of the WG
+## Description of the group
 
-Here follows the description of the WG, its challenges and the questions which it should address, as defined by the WG itself during the Visualization session in the HSF Workshop in San Diego (see link in the meetings' list below).
+Here follows the description of the group, its challenges and the questions which it should address, as defined by the group itself during the Visualization session in the HSF Workshop in San Diego (see link in the meetings' list below).
 
-The first task of the WG was the writing of a [common white paper](http://hepsoftwarefoundation.org/activities/cwp.html) about Visualization issues and challenges in HEP, and possible solutions, in a time scale of 5-10 years. The paper is now completed and published on arXiV: <https://arxiv.org/abs/1811.10309>.
+The first task of the group was the writing of a [common white paper](http://hepsoftwarefoundation.org/activities/cwp.html) about Visualization issues and challenges in HEP, and possible solutions, in a time scale of 5-10 years. The paper is now completed and published on arXiV: <https://arxiv.org/abs/1811.10309>.
 
 
-### Scope of the WG activities
+### Scope of the group activities
 
 Visual representation of event data overlaid with detector geometry for the purpose of  HEP research, education and outreach. This representation can be static (event displays) or time-dependent (animations).
 
@@ -42,7 +42,7 @@ Visual representation of event data overlaid with detector geometry for the purp
 Visualization of detector infrastructure and systems (eg. slow control)
 Visualization for statistical data analysis (histograms, etc…)
 
-### WG Challenges
+### Group Challenges
 
 * Find common approaches, promoting common tools
 * Improve support for the following use cases:
@@ -55,7 +55,7 @@ Visualization for statistical data analysis (histograms, etc…)
 * Improve low latency access to data, low entrance cost, from a visualization point of view
 * Improve rendering performance
 
-### Some open question to shape the WG activities
+### Some open question to shape the group activities
 
 * Can we develop a common framework such that experiments can plug in geometry and event data in their own formats/data?
 * Can the data delivery be web-based?
@@ -63,9 +63,9 @@ Visualization for statistical data analysis (histograms, etc…)
 * Can we have common graphics engine?
 * Can we think about common visualization tools with other fields (astrophysics, geophysics, etc…)? And can we learn something from them?
 
-### Interaction with other WGs
+### Interaction with other groups
 
-Topics for which we will have to interact with other WGs:
+Topics for which we will have to interact with other groups:
 
 *	Data access (data  handling, frameworks)
 *	Geometry description (simulation group)
@@ -76,7 +76,7 @@ Topics for which we will have to interact with other WGs:
 
 * HSG "Visualization" Community White Paper: <https://arxiv.org/abs/1811.10309>
 
-* Working Group's [charge document](https://docs.google.com/document/d/1ZXiMMmmAj1lwQIuvDc2UM4Jx6-hh1iamIw79DXguLIM/edit), as defined by the WG in the January 2017 San Diego Workshop
+* Working Group's [charge document](https://docs.google.com/document/d/1ZXiMMmmAj1lwQIuvDc2UM4Jx6-hh1iamIw79DXguLIM/edit), as defined by the group in the January 2017 San Diego Workshop
 
 
 ----

--- a/_activities/visualization.md
+++ b/_activities/visualization.md
@@ -1,14 +1,15 @@
 ---
-title: "Visualization"
+title: "Visualisation"
 author: "Riccardo Maria Bianchi"
 layout: plain
 redirect_from: 
-  - /workinggroups/visualization.html
+  - /workinggroups/Visualisation.html
+  - /workinggroups/visualisation.html
 ---
 
-The Visualisation Activity Area gathers experts, developers, users and all people from the Particle Physics community interested in interactive data visualization and event displays. 
+The Visualisation Activity Area gathers experts, developers, users and all people from the Particle Physics community interested in interactive data visualisation and event displays. 
 
-The group was been started in October 2016 and it is convened by Riccardo Maria Bianchi (*University of Pittsburgh, US*, ATLAS Experiment). 
+The group started activities in October 2016 and it is convened by Riccardo Maria Bianchi (*University of Pittsburgh, US*, ATLAS Experiment). 
 
 All are welcome to join the group and participate!
 
@@ -16,7 +17,7 @@ All are welcome to join the group and participate!
 
 Convenor: [Riccardo Maria BIANCHI](mailto:riccardo.maria.bianchi@cern.ch) (ATLAS)
 
-Mailing list: [hsf-visualization-wg@googlegroups.com](mailto:hsf-visualization-wg@googlegroups.com)
+Mailing list: [hsf-Visualisation-wg@googlegroups.com](mailto:hsf-Visualisation-wg@googlegroups.com)
 
 ----
 
@@ -28,9 +29,9 @@ The goal of the group is to discover common approaches, foster collaboration amo
 
 ## Description of the group
 
-Here follows the description of the group, its challenges and the questions which it should address, as defined by the group itself during the Visualization session in the HSF Workshop in San Diego (see link in the meetings' list below).
+Here follows the description of the group, its challenges and the questions which it should address, as defined by the group itself during the Visualisation session in the HSF Workshop in San Diego (see link in the meetings' list below).
 
-The first task of the group was the writing of a [common white paper](http://hepsoftwarefoundation.org/activities/cwp.html) about Visualization issues and challenges in HEP, and possible solutions, in a time scale of 5-10 years. The paper is now completed and published on arXiV: <https://arxiv.org/abs/1811.10309>.
+The first task of the group was the writing of a [common white paper](http://hepsoftwarefoundation.org/activities/cwp.html) about Visualisation issues and challenges in HEP, and possible solutions, in a time scale of 5-10 years. The paper is now completed and published on arXiV: <https://arxiv.org/abs/1811.10309>.
 
 
 ### Scope of the group activities
@@ -39,8 +40,8 @@ Visual representation of event data overlaid with detector geometry for the purp
 
 #### Out of scope
 
-Visualization of detector infrastructure and systems (eg. slow control)
-Visualization for statistical data analysis (histograms, etc…)
+- Visualisation of detector infrastructure and systems (eg. slow control)
+- Visualisation for statistical data analysis (histograms, etc…)
 
 ### Group Challenges
 
@@ -52,16 +53,16 @@ Visualization for statistical data analysis (histograms, etc…)
     * outreach & education
 * Improve support for required platforms and devices
 * Ensure sustainability for key software packages
-* Improve low latency access to data, low entrance cost, from a visualization point of view
+* Improve low latency access to data, low entrance cost, from a sisualisation point of view
 * Improve rendering performance
 
 ### Some open question to shape the group activities
 
 * Can we develop a common framework such that experiments can plug in geometry and event data in their own formats/data?
 * Can the data delivery be web-based?
-* Can we develop a collaborative (“multi-player”) tool to visualize and interact with event data and geometry in real time and a distributed manner (Google doc for visualization)? How will this capability advance HEP research and outreach?
+* Can we develop a collaborative (“multi-player”) tool to visualize and interact with event data and geometry in real time and a distributed manner (Google doc for sisualisation)? How will this capability advance HEP research and outreach?
 * Can we have common graphics engine?
-* Can we think about common visualization tools with other fields (astrophysics, geophysics, etc…)? And can we learn something from them?
+* Can we think about common visualisation tools with other fields (astrophysics, geophysics, etc…)? And can we learn something from them?
 
 ### Interaction with other groups
 
@@ -74,7 +75,7 @@ Topics for which we will have to interact with other groups:
 
 ## Documents
 
-* HSG "Visualization" Community White Paper: <https://arxiv.org/abs/1811.10309>
+* HSG "Visualisation" Community White Paper: <https://arxiv.org/abs/1811.10309>
 
 * Working Group's [charge document](https://docs.google.com/document/d/1ZXiMMmmAj1lwQIuvDc2UM4Jx6-hh1iamIw79DXguLIM/edit), as defined by the group in the January 2017 San Diego Workshop
 
@@ -83,15 +84,15 @@ Topics for which we will have to interact with other groups:
 
 ## Meetings
 
-### HSF Workshop 2018 - Visualization session, Naples, 28 March 2018
+### HSF Workshop 2018 - Visualisation session, Naples, 28 March 2018
 
 * [Agenda](https://indico.cern.ch/event/658060/sessions/266387/#20180328)
 
-### HSF Mini-workshop on GUI, graphic libraries, interactive visualization, CERN, 7 April 2017
+### HSF Mini-workshop on GUI, graphic libraries, interactive Visualisation, CERN, 7 April 2017
 
 * [Agenda](https://indico.cern.ch/event/628675/)
 
-### HSF Visualization Workshop, CERN, 28-30 March 2017
+### HSF Visualisation Workshop, CERN, 28-30 March 2017
 
 * [Agenda](https://indico.cern.ch/event/617054/)
 * Discussion's [Live notes](https://indico.cern.ch/event/617054/contributions/2526122/attachments/1436308/2208777/go)
@@ -99,5 +100,5 @@ Topics for which we will have to interact with other groups:
 ### HSF Workshop, San Diego, 23-26 January 2017
 
 * [Workshop agenda](https://indico.cern.ch/event/570249/)
-* Visualization session's [agenda](https://indico.cern.ch/event/570249/sessions/217071/#20170125)
+* Visualisation session's [agenda](https://indico.cern.ch/event/570249/sessions/217071/#20170125)
 * All the [contributions](https://indico.cern.ch/event/570249/contributions/2450053/)

--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -14,7 +14,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="/index.html" id="activities_menu">Activities<span class="caret"></span></a>
                 <ul class="dropdown-menu" aria-labelledby="activities_menu">
-                 <li><a href="/events.html">Events &amp; Workshops</a></li>
+                 <li><a href="/what_are_activities.html">What are HSF activity areas?</a></li>
                  <li class="divider"></li>
                  {% for activity in site.activities %}
                    <li><a href="{{ activity.url }}">{{ activity.title }}</a></li>
@@ -36,6 +36,7 @@
                 <ul class="dropdown-menu" aria-labelledby="communication_menu">
                   <li><a href="https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&ctz=Europe/Amsterdam">Community Calendar</a></li>
                   <li><a href="/Schools/events.html">Training Schools</a></li>
+                  <li><a href="/events.html">Events &amp; Workshops</a></li>
                   <li class="divider"></li>
                   <li><a href="/forums.html">Mailing Lists and Forums</a></li>
                   <li><a href="/technical_notes.html">Technical Notes</a></li>

--- a/get_involved.md
+++ b/get_involved.md
@@ -9,7 +9,7 @@ layout: default
 Our goal is to make every effort going on as transparent and open as possible.
 Our official communication channel is the 
 [hsf-forum](https://groups.google.com/forum/#!forum/hsf-forum). If you want to contact
-a smaller group of HSF advovates you can get in touch with the
+a smaller group of HSF advocates you can get in touch with the
 [HSF Coordination Team](/organization/team.html).
 
 See the [dedicated page](/forums.html) about HSF discussions forums for 
@@ -22,7 +22,7 @@ There are plenty of opportunities for you to contribute to the HSF, be it by
 participation in technical discussions, by joining one of our working groups, or
 by joining the HSF with your software project:
 
-  *  Participation in HSF [working groups](/what_are_WGs.html) and activities
+  *  Participation in HSF [working groups](/what_are_WGs.html) and [activity areas](/what_are_activities.html)
   *  Participation in [HSF events and meetings](/future-events.html)
   *  Taking advantage of the HSF by indentifying your [software project](/projects.html) with us
   *  Giving input to the [HSF Coordination Team](/organization/team.html)
@@ -33,11 +33,10 @@ by joining the HSF with your software project:
 See the [Events listing](/future-events.html) on this site for information on HSF meetings, workshops,
 etc. 
 
-Meetings use the [CERN Indico system](http://indico.cern.ch/category/5816/) for agenda pages. The agenda pages are generally open to the world, and no CERN account needed. 
+Meetings use the [CERN Indico system](http://indico.cern.ch/category/5816/) for agenda pages. The agenda pages are generally open to the world, and no CERN account is needed. To upload material to Indico you do need to be identified CERN now allows EduGain authentication
+to many of its services, if you do not have a full CERN account.
 
-The [Vidyo](http://information-technology.web.cern.ch/services/fe/vidyo) video conferencing system is used for all HSF meetings and anyone can participate in the meetings from any internet-connected location. Connection information for each specific Vidyo meeting is on the corresponding Indico meeting agenda page.
-(To upload material to Indico you do need to be identified, in addition to a CERN computing account CERN now allows EduGain authentication
-to many of its services.)
+The [Vidyo](http://information-technology.web.cern.ch/services/fe/vidyo) video conferencing system is used for almost all HSF meetings and anyone can participate in the meetings from any internet-connected location. Connection information for each specific Vidyo meeting is on the corresponding Indico meeting agenda page.
 
 ## Giving input to the HSF Coordination Team
 

--- a/get_involved.md
+++ b/get_involved.md
@@ -8,7 +8,9 @@ layout: default
 
 Our goal is to make every effort going on as transparent and open as possible.
 Our official communication channel is the 
-[hsf-forum](https://groups.google.com/forum/#!forum/hsf-forum). 
+[hsf-forum](https://groups.google.com/forum/#!forum/hsf-forum). If you want to contact
+a smaller group of HSF advovates you can get in touch with the
+[HSF Coordination Team](/organization/team.html).
 
 See the [dedicated page](/forums.html) about HSF discussions forums for 
 information about how to register and the
@@ -20,25 +22,27 @@ There are plenty of opportunities for you to contribute to the HSF, be it by
 participation in technical discussions, by joining one of our working groups, or
 by joining the HSF with your software project:
 
-  *  Participation in HSF activities and forums. See the Activities page.
-  *  Participation in HSF events and meetings.
-  *  Contributing to the [HEP S&C Knowledge Base](http://hepsoftware.org)
-  *  Taking advantage for your project from the HSF (to be created)
-  *  Giving input to the HSF startup team
+  *  Participation in HSF [working groups](/what_are_WGs.html) and activities
+  *  Participation in [HSF events and meetings](/future-events.html)
+  *  Taking advantage of the HSF by indentifying your [software project](/projects.html) with us
+  *  Giving input to the [HSF Coordination Team](/organization/team.html)
   *  Contributing to this website
 
 ## Meetings, Agendas and Video-Conferences Access
 
-See the Events listing on this site for information on HSF meetings, workshops,
-etc. Meetings use the [CERN Indico system](http://indico.cern.ch/category/5816/) for agenda pages. The agenda pages are open to the world, and no CERN account needed. The Vidyo video conferencing system is used for all HSF meetings and anyone can participate in the meetings from any internet-connected location. 
-Connection information for each specific Vidyo meeting is on the corresponding Indico meeting agenda page.  Vidyo has a web-browser interface, or alternatively one can [download the Vidyo desktop client (standalone application)](http://information-technology.web.cern.ch/services/fe/howto/users-install-vidyo-desktop-client).  However should you need to upload material to the
-agenda, a CERN account is needed. CERN provides lightweight accounts to non CERN
-affiliated people when needed. See <https://account.cern.ch/account/Externals/>
+See the [Events listing](/future-events.html) on this site for information on HSF meetings, workshops,
+etc. 
+
+Meetings use the [CERN Indico system](http://indico.cern.ch/category/5816/) for agenda pages. The agenda pages are generally open to the world, and no CERN account needed. 
+
+The [Vidyo](http://information-technology.web.cern.ch/services/fe/vidyo) video conferencing system is used for all HSF meetings and anyone can participate in the meetings from any internet-connected location. Connection information for each specific Vidyo meeting is on the corresponding Indico meeting agenda page.
+(To upload material to Indico you do need to be identified, in addition to a CERN computing account CERN now allows EduGain authentication
+to many of its services.)
 
 ## Giving input to the HSF Coordination Team
 
-If you are not comfortable with raising an issue in the
-[forums](/forums.html) or if you are afraid that this is not the
+If you are not certain about raising an issue in the
+[forums](/forums.html) and mailing lists, or if you are afraid that this is not the
 right place for it, feel free to contact the
 [HSF coordination team](mailto:hsf-coordination@googlegroups.com) directly.
 
@@ -50,13 +54,3 @@ find instructions on how to do it [here](/howto-website.html).
 ## Add events to the community calendar
 
 See [this short guide](/calendar.html) for how to add next events to the calendar.
-
-
-## Contributing to the HSF S&C Knowledge Base
-
-The HSF provides a S&C knowledge base at 
-[hepsoftware.org](http://hepsoftware.org) cataloging software in use by the 
-community, who uses it, etc. The knowledge base relies on community input if it 
-is to become comprehensive and useful. Please add, update, elaborate, correct 
-entries for your favorite software packages, experiments, etc. All are welcome 
-and encouraged to add and edit material.

--- a/howto-website.md
+++ b/howto-website.md
@@ -47,7 +47,7 @@ the content into the HSF website for archiving.
 CERN has its own [CodiMD instance](https://codimd.web.cern.ch/), but currently this only
 works if every contributor has a full CERN account (EduGain authentication is proposed,
 but it doesn't work yet AFAWU). An alternative is the [demo CodiMD service](https://demo.codimd.org/),
-but be aware that there is no long term gaurantee for content here, so move it to the 
+but be aware that there is no long term guarantee for content here, so move it to the 
 website after your meeting.
 
 We find that *recycling* the same document for a series of meetings is extremely useful
@@ -79,7 +79,7 @@ in there. The [Events](http://hepsoftwarefoundation.org/events.html) page and th
 
 For *training events* we have a special handling that lists all of these together on the 
 [Training Working Group page](workinggroups/training.html). To create a new
-entry add a new markdown file into `Schools/_posts`. The exisiting entries are a guide to
+entry add a new Markdown file into `Schools/_posts`. The existing entries are a guide to
 the metadata which is needed.
 
 ### Adding news or announcements

--- a/howto-website.md
+++ b/howto-website.md
@@ -10,7 +10,7 @@ This site is maintained by the HSF GitHub [contributors](https://github.com/orgs
 
 ## Implementation
 
-This website is implemented using [GitHub's Pages](https://pages.github.com/) service which makes it easy to create a website associated with a GitHub account or project. Pages uses [Jekyll](https://help.github.com/articles/using-jekyll-with-pages/), a tool to automatically build a website from source files (which are kept in GitHub). It supports structured sites like blogs in a simple but powerful way.
+This website is implemented using [GitHub's Pages](https://pages.github.com/) service, which makes it easy to create a website associated with a GitHub account or project. Pages uses [Jekyll](https://help.github.com/articles/using-jekyll-with-pages/), a tool to automatically build a website from source files (which are kept in GitHub). It supports structured sites like blogs in a simple but powerful way.
 The site content is written using the easy [Markdown syntax](http://daringfireball.net/projects/markdown/syntax) (which is used by GitHub itself).
 
 A [HSF documentation](/jekyll-beginners.html) provides some useful hints to make using Jekyll in the HSF context easier.
@@ -24,7 +24,7 @@ files you want to edit, push them to your fork, and open a pull request.
 
 If you wish (and it is recommended) you can easily set up a local instance of the newsletter site in order to preview your submissions. See the [documentation](https://help.github.com/articles/using-jekyll-with-pages/)
 on installing and running Jekyll.
-The website uses the master branch of the hsf.github.io repository.
+The website uses the master branch of the [hsf.github.io](https://github.com/HSF/hsf.github.io) repository.
 
 If you are not familiar with GitHub and Git, you can read our [survival kit](/github-beginners.html)!
 
@@ -35,18 +35,38 @@ e.g., the author of the document or the title of the document.
 
 In the *front-matter* (but not in the text itself), you need to replace any `&` characters (which has a special meaning in HTML) by `&amp;`. This is particularly important for the `title` attribute.
 
-### Adding contents from GoogleDoc
+### Adding content from collaborative tools
 
-It is sometimes handy to use GoogleDoc to produce some contents for the web site. For example, if taking minutes
-during a meeting, it allows several people to contribute to the effort of note taking and other persons who attended the
-meeting to validate/update them. It is then easy to convert a properly formatted GoogleDoc (using standard heading
-levels) to Markdown for inserting it into the website. Look at our [documentation](/jekyll-beginners.html) on how to
-do it.
+#### CodiMD
+
+The recommended way to host a collaborative note book, e.g. for taking meeting minutes
+is to use [CodiMD](https://hackmd.io/c/codimd-documentation/%2Fs%2Fcodimd-documentation), which is
+a collaborative ediitng tool utilising Markdown directly. This makes it trivial to move
+the content into the HSF website for archiving.
+
+CERN has its own [CodiMD instance](https://codimd.web.cern.ch/), but currently this only
+works if every contributor has a full CERN account (EduGain authentication is proposed,
+but it doesn't work yet AFAWU). An alternative is the [demo CodiMD service](https://demo.codimd.org/),
+but be aware that there is no long term gaurantee for content here, so move it to the 
+website after your meeting.
+
+We find that *recycling* the same document for a series of meetings is extremely useful
+as the *live notes* link can be copied and cloned from one meeting to the next.
+
+#### GoogleDocs
+
+Google Docs can also be used for shared notebooks, but in this case there is a need to convert
+the document to Markdown before it can be added to the website. This is less convenient, but
+we have [documentation](/jekyll-beginners.html) on how to do it.
 
 
 ### Adding a working group or activity
 
-Add a new file in the `_workinggroups` or `_activities` directory and follow the front-matter of the
+*Before adding any new activity or proposing a new working group please discuss with the
+[HSF Coordination Team](/organization/team.html)! We will make sure it gets proposed
+in an HSF meeting for approval.*
+
+Then, for the technical creation, add a new file in the `_workinggroups` or `_activities` directory. Follow the front-matter of the
 other files in there. The `Working Groups` / `Activities` menu in the navigation bar will
 be updated automatically: the menu entry text is the `title` attribute in the *front-matter* section.
 
@@ -55,6 +75,13 @@ be updated automatically: the menu entry text is the `title` attribute in the *f
 Add a new file in `events/_posts` and follow the *front-matter* (see above) of the other files
 in there. The [Events](http://hepsoftwarefoundation.org/events.html) page and the ``Upcoming Events`` sidebar will be updated automatically.
 
+### Adding a training event
+
+For *training events* we have a special handling that lists all of these together on the 
+[Training Working Group page](workinggroups/training.html). To create a new
+entry add a new markdown file into `Schools/_posts`. The exisiting entries are a guide to
+the metadata which is needed.
+
 ### Adding news or announcements
 
 Add a new file in `announcements/_posts` and follow the front matter of the other files in there. The front page will
@@ -62,6 +89,14 @@ get a new box with all information.
 
 Please don't forget adding an event ``until`` in the *front-matter*: this is used for ordering events **and** as the end date
 for adding the event in the ``Upcoming Events`` sidebar.
+
+### Adding a newsletter
+
+[Newsletters](/newsletter.html) are occasional longer articles we publish. Each of these lives in `newsletter/_posts`.
+The format is very similar to the other
+content on the website, follow the front matter of the other files in there. 
+
+You can highlight a newsletter by updating the centre column of the frontpage of the website (see below).
 
 ## Technical details
 

--- a/jekyll-beginners.md
+++ b/jekyll-beginners.md
@@ -70,10 +70,14 @@ Look at the source of this page for an example.
 
 ### Converting Contents from Word or GoogleDoc
 
+Note that CodiMD is a better alternative for collaborative text which is destined for
+this website as it uses Markdown natively. However, if you do need to work from another
+source then...
+
 [pandoc](http://pandoc.org) is the swiss-army knife for the conversion between text formats. In particular it supports a very good conversion from Microsoft Word (`docx`) format to Jekyll markdown. The typical command to do this conversion is:
 
 ```
-pandoc -t markdown_github --base-header-level=2 --atx-headers -o organization/_posts/2016-05-19-startup.md document.docx
+pandoc -t gmf --base-header-level=2 --atx-headers -o organization/_posts/2016-05-19-startup.md document.docx
 ```
 
 This method can be used to convert a GoogleDoc document to markdown. To do it, use the GoogleDoc menu `File->Download as` and export the GoogleDoc document as a `docx` file. Then use the command above to convert to markdown.

--- a/what_are_WGs.md
+++ b/what_are_WGs.md
@@ -1,22 +1,29 @@
 ---
 title: "What are working groups?"
-author: "Benedikt Hegner"
+author: "Graeme Stewart"
 layout: default
 ---
 
 # Working Groups
 
-Working Groups can be ad-hoc formed groups of people interested in
-tackling a problem together
-as well as by the HSF setting strategic directions.
-If you want to form a working group or want to put some community-wide
+HSF Working Groups are community led groups that organise activities
+in particular domains with the aims of increading communication
+between developers, providing a platform for discussion of interesting
+problems and novel solutions developments, and fostering the adoption
+of common software between different communities.
+
+Working groups have three convenors, to help share the workload, and
+are appointed by the HSF (via an open nomination process and a search
+committtee) to serve for one year, with renewal possible by mutual
+agreement. (Interest groups and activity areas are less formal.)
+
+If you want to form a working group, or want to put some community-wide
 activity under the umbrella of the HSF,
 just contact the
-[HSF coordination team](mailto:hsf-coordination@googlegroups.com) and we will
-announce your activities here.
+[HSF coordination team](mailto:hsf-coordination@googlegroups.com).
 
-Working Groups will be added to the activities listing of the HSF,
-can add material to the website and can have a dedicated mailing list
+Working Groups are added to the website of the HSF, with 
+description and contact information and will have a dedicated mailing list
 and Indico category.
 
 <ul class="list">

--- a/what_are_activities.md
+++ b/what_are_activities.md
@@ -6,7 +6,7 @@ layout: default
 
 # Activity Areas and Interest Groups
 
-HSF Activity Areas and Interest Groups are led by enthisiasts and
+HSF Activity Areas and Interest Groups are led by enthusiasts and
 advocates for a particular area of work or of technology
 interest and provide a focal point for organising dicussions
 in the HEP community. They can also cover engagement with

--- a/what_are_activities.md
+++ b/what_are_activities.md
@@ -1,0 +1,30 @@
+---
+title: "What are activity areas?"
+author: "Graeme Stewart"
+layout: default
+---
+
+# Activity Areas and Interest Groups
+
+HSF Activity Areas and Interest Groups are led by enthisiasts and
+advocates for a particular area of work or of technology
+interest and provide a focal point for organising dicussions
+in the HEP community. They can also cover engagement with
+external projects, like Google's Summer of Code.
+
+They are less formal, in the HSF, than [working groups](/what_are_WGs.html)
+and any relevant and reasonable activity for HEP can spawn
+an interest group. If you want to put some community-wide
+activity under the umbrella of the HSF as an activity areas or interest group
+just contact the
+[HSF coordination team](mailto:hsf-coordination@googlegroups.com).
+
+Activity areas are added to the website of the HSF, with 
+description and contact information and will have a dedicated mailing list
+and, if appropriate, an Indico category.
+
+<ul class="list">
+{% for activity in site.activities %}
+  <li> <a href="{{ activity.url }}">{{ activity.title }}</a></li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
Add more links to the "getting involved" page and concentrate on more relevant areas
Update the website's HOWTO guide, in particular recommend CodiMD for note taking
Bring the pandoc options example up to date
Better description of what WGs are, outlining how they for and how convenors are appointed
Add a similar description to activity areas so that people understand the difference
Updates to the navbar to add new content

Cleaned up the visualisation page, reflecting new status
