### PR TITLE
Change title of training school page

### DIFF
--- a/Schools/events.md
+++ b/Schools/events.md
@@ -1,6 +1,6 @@
 ---
 layout: plain
-title: Schools for HSF Training
+title: Schools for HEP Software Training
 ---
 
 {% include list_of_schools.md %}


### PR DESCRIPTION
We just discussed this in the training meeting: https://hepsoftwarefoundation.org/Schools/events.html is titled "Schools for HSF Training", even though only a subset of the schools advertised has us involved at all. Rather, this is meant as a list of any event concerened with HEP Software training.

Hence a title change.