### PR TITLE
[minor] Fix typo in IJCLab description, and remove unecessary summary section.

### DIFF
--- a/_gsocorgs/2020/ijclab.md
+++ b/_gsocorgs/2020/ijclab.md
@@ -6,7 +6,7 @@ organization: IJCLab
 logo: IJCLab-logo.jpeg
 description: |
   [IJCLab](http://www.lal.in2p3.fr) is a French research laboratory belonging to CNRS/IN2P3 and located at Université
-  Paris Saclay. The main topics of the research done at LAL are high energy physics, cosmology and accelerators.
+  Paris Saclay. The main topics of the research done at IJCLab are high energy physics, cosmology and accelerators.
 ---
 
 {% include gsoc_proposal.ext %}

--- a/_gsocprojects/2020/project_AstroLab.md
+++ b/_gsocprojects/2020/project_AstroLab.md
@@ -4,8 +4,6 @@ layout: default
 logo: Astrolab-logo.png
 description: |
   [AstroLab Software](https://astrolabsoftware.github.io/) is a project from [IJCLab](https://www.lal.in2p3.fr/en/) aiming at providing advanced software tools to overcome modern science challenges faced by research groups, and allow research communities to more fully exploit the big data ecosystem tools.
-summary: |
-  [AstroLab Software](https://astrolabsoftware.github.io/) is a project from [IJCLab](https://www.lal.in2p3.fr/en/) aiming at providing advanced software tools to overcome modern science challenges faced by research groups, and allow research communities to more fully exploit the big data ecosystem tools.
 ---
 
 {% include gsoc_project.ext %}


### PR DESCRIPTION
Dear HSF GSoC 2020 admin team,

I spotted and corrected a typo in the IJCLab organisation description.

I also removed the unnecessary summary section in the header of the AstroLab project description (see @agheata inlined comment in #682 ).
