### PR TITLE
Add page describing how to get letters of support/cooperation from HSF

### DIFF
--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -65,6 +65,7 @@
                 <li class="divider"></li>
                 <li><a href="/organization/goals.html">Goals of the HSF</a></li>
                 <li><a href="/organization/cwp.html">Community White Paper</a></li>
+                <li><a href="/organization/hsf-letters.html">Letters from the HSF</a></li>
                 <li><a href="/organization/team.html">The Coordination Team</a></li>
                 <li><a href="/organization/presentations.html">HSF Presentations</a></li>
                 <li class="divider"></li>

--- a/organization/hsf-letters.md
+++ b/organization/hsf-letters.md
@@ -16,7 +16,7 @@ shares similar goals.
 ### Letters of Cooperation
 
 We will be happy to provide a *letter of cooperation*
-that can be used for any funding application. To ask us
+that can be used for any software project or funding application. To ask us
 for this please:
 
 - Send an email request to [HSF Coordination](mailto:hsf-coordination@googlegroups.com)

--- a/organization/hsf-letters.md
+++ b/organization/hsf-letters.md
@@ -1,0 +1,47 @@
+---
+title: "Letters from the HSF"
+author: "Graeme Stewart"
+layout: default
+---
+
+# {{page.title}}
+
+The HSF's mission is to encourage cooperation and common projects
+between all parts of the high-energy physics community concerned
+with software. We span regions and experiments and we strive to 
+to make our community's software development more effective.
+To that end, the HSF will happily cooperate with any project that
+shares similar goals. 
+
+### Letters of Cooperation
+
+We will be happy to provide a *letter of cooperation*
+that can be used for any funding application. To ask us
+for this please:
+
+- Send an email request to [HSF Coordination](mailto:hsf-coordination@googlegroups.com)
+- Include an outline of your project's goals and indicate where you
+  believe that the HSF can usefully cooperate with you
+- Please make this request at least *two weeks* before you need the letter
+
+### Letters of Support
+
+If you would like a *letter of support* for your project then you
+should additionally show how your project will help to meet the goals
+of the HSF as set out, for example, in the [Community White Paper](/organization/cwp.html).
+Please note that a letter of support will not be exclusive for any
+particular grant application round - the HSF is free to support multiple
+projects.
+
+- Send an email request to [HSF Coordination](mailto:hsf-coordination@googlegroups.com)
+- Include an outline of your project's goals and indicate in what way
+  this helps the high-energy physics community to meet the software challenges
+  of the future
+- Please make this request at least *three weeks* before you need the letter
+
+### Proceedure
+
+In both cases the HSF Coordination group will discuss the request and, if approved,
+circulate a draft letter to the whole of the HSF community for any comments. We will
+then approve the request in an HSF Coordination meeting (or, exceptionally, just by email,
+should deadlines not fit with the meeting schedule).

--- a/organization/hsf-letters.md
+++ b/organization/hsf-letters.md
@@ -39,7 +39,7 @@ projects.
   of the future
 - Please make this request at least *three weeks* before you need the letter
 
-### Proceedure
+### Procedure
 
 In both cases the HSF Coordination group will discuss the request and, if approved,
 circulate a draft letter to the whole of the HSF community for any comments. We will


### PR DESCRIPTION
Describe the proceedure for getting a letter of cooperation or a letter of support from the HSF.

Letters of cooperation are fairly standard for NSF applications, but don't imply a lot of endorsment.

Letters of support have a higher level of implicit endorsement, so we ask for a bit more from people in this case.