### PR TITLE
Fix all persistently broken URLs

### DIFF
--- a/_data/training-schools.yml
+++ b/_data/training-schools.yml
@@ -151,6 +151,7 @@
   end_date: 2020-03-29
   source: http://hep2020.tpu.ru/webcenter/portal/transib2020/page15?_adf.ctrl-state=2shs7c3nq_4
   title: 3rd Trans-Siberian School of High Energy Physics
+  url_proof_ignore: True
 - author: Kilian Lieret
   date: 2020-04-27
   deadline: ''

--- a/_gsocprojects/2018/project_NEXT.md
+++ b/_gsocprojects/2018/project_NEXT.md
@@ -3,7 +3,7 @@ project: NEXT
 layout: default
 logo: NEXT-logo.png
 description: |
-  [NEXT](http://next.ific.uv.es/next/) is a Xenon gas neutrino-less double beta decay experiment.
+  [NEXT](https://next.ific.uv.es/next/) is a Xenon gas neutrino-less double beta decay experiment.
 ---
 
 

--- a/_gsocproposals/2018/proposal_ROOTgit.md
+++ b/_gsocproposals/2018/proposal_ROOTgit.md
@@ -42,7 +42,7 @@ The project is divided in four parts:
 # Possible extensions
 
 A natural extension of this work, if the student has a Windows machine
-available, is to study the interplay with [Microsoft's GVFS](https://gvfs.io).
+available, is to study the interplay with [Microsoft's GVFS](https://github.com/Microsoft/VFSForGit).
 
 # Mentors
 

--- a/_gsocproposals/2018/proposal_WLCGLightweightSiteConfiguration.md
+++ b/_gsocproposals/2018/proposal_WLCGLightweightSiteConfiguration.md
@@ -38,7 +38,6 @@ The Worldwide LHC Computing Grid (WLCG) unites resources from over 160 computing
 **Links**:
   * [WLCG](http://wlcg.web.cern.ch)
   * [Next Steps : Lightweight Sites Web Forums](https://groups.google.com/forum/#!forum/wlcg-lightweight-sites)
-  * [Git Repositories](https://github.com/WLCG-Lightweight-Sites)
-  * Introduction to WLCG (http://litmaath.web.cern.ch/litmaath/grids-intro/wlcg-intro-180130-long.pdf)
+  * Git Repositories - https://github.com/WLCG-Lightweight-Sites
   * [Introduction to WLCG Lightweight Sites](https://indico.jinr.ru/contributionDisplay.py?contribId=219&confId=151)
   * [Puppet VM Learning Guide](https://puppet.com/download-learning-vm?_ga=1.75488720.375650118.1442481193)

--- a/_gsocproposals/2018/proposal_WLCGLightweightSiteOrchestration.md
+++ b/_gsocproposals/2018/proposal_WLCGLightweightSiteOrchestration.md
@@ -39,6 +39,5 @@ The Worldwide LHC Computing Grid (WLCG) unites resources from over 160 computing
 **Links**:
 * [WLCG](http://wlcg.web.cern.ch)
 * [Next Steps : Lightweight Sites Web Forums](https://groups.google.com/forum/#!forum/wlcg-lightweight-sites)
-* [Git Repositories](https://github.com/WLCG-Lightweight-Sites)
 * Introduction to WLCG (http://litmaath.web.cern.ch/litmaath/grids-intro/wlcg-intro-180130-long.pdf)
 * [Introduction to WLCG Lightweight Sites](https://indico.jinr.ru/contributionDisplay.py?contribId=219&confId=151)

--- a/_gsocproposals/2019/proposal_ROOTIpopt.md
+++ b/_gsocproposals/2019/proposal_ROOTIpopt.md
@@ -36,8 +36,6 @@ Documentation, tests and examples.
   * [Lorenzo Moneta](mailto:Lorenzo.Moneta@cern.ch)
 
 ## Links
-  1. [Ipopt](https://projects.coin-or.org/Ipopt)
+  1. [Ipopt](https://github.com/coin-or/Ipopt)
   2. [Github](https://github.com/oprojects/root/tree/master-ipopt/math/ipopt)
-  3. [Ipopt MultiMin](http://clusteri.itm.edu.co/rootdoc/html/group__MultiMin.html)
   4. [ROOT Ipopt](http://oproject.org/pages/Ipopt.html)
-  5. [Ipopt Solvers](https://www.coin-or.org/Ipopt/documentation/node51.html)

--- a/_gsocproposals/2019/proposal_WLCGansible.md
+++ b/_gsocproposals/2019/proposal_WLCGansible.md
@@ -49,7 +49,6 @@ The functions of the Central Configuration Manager are described in the SIMPLE f
 **Links**:
 * [Lightweight Sites Web Forum (request membership)](https://groups.google.com/forum/#!forum/wlcg-lightweight-sites)
 * [Next Steps](https://groups.google.com/forum/#!category-topic/wlcg-lightweight-sites/gsoc/T5OtDT-W79c)
-* [Git Repositories](https://github.com/WLCG-Lightweight-Sites)
 * [Introduction to SIMPLE Grid Framework](https://speakerdeck.com/maany/the-simple-framework-deploy-complex-clusters-with-ease)
 * [SIMPLE Grid Project  : CHEP 2018 Conference Proceedings paper](https://cernbox.cern.ch/index.php/s/OCqVQ55Q3bjzs7x)
 * [SIMPLE Grid Specification Document (Early draft)](https://docs.google.com/document/d/1yp_96UXcwNO49cktnHtT61iNmTO0RgrSQukuNYqACpM/edit#heading=h.3etse5r12l7p)

--- a/_gsocproposals/2019/proposal_WLCGpython.md
+++ b/_gsocproposals/2019/proposal_WLCGpython.md
@@ -53,7 +53,6 @@ A more consolidated set of tasks is as follows:
 **Links**:
 * [Lightweight Sites Web Forum (request membership)](https://groups.google.com/forum/#!forum/wlcg-lightweight-sites)
 * [Next Steps](https://groups.google.com/forum/#!category-topic/wlcg-lightweight-sites/gsoc/W45nOZtA98I)
-* [Git Repositories](https://github.com/WLCG-Lightweight-Sites)
 * [Introduction to SIMPLE Grid Framework](https://speakerdeck.com/maany/the-simple-framework-deploy-complex-clusters-with-ease)
 * [SIMPLE Grid Project  : CHEP 2018 Conference Proceedings paper](https://cernbox.cern.ch/index.php/s/OCqVQ55Q3bjzs7x)
 * [SIMPLE Grid Specification Document (Early draft)](https://docs.google.com/document/d/1yp_96UXcwNO49cktnHtT61iNmTO0RgrSQukuNYqACpM/edit#heading=h.3etse5r12l7p)

--- a/_gsocproposals/2019/proposal_WLCGpython.md
+++ b/_gsocproposals/2019/proposal_WLCGpython.md
@@ -58,6 +58,5 @@ A more consolidated set of tasks is as follows:
 * [SIMPLE Grid Project  : CHEP 2018 Conference Proceedings paper](https://cernbox.cern.ch/index.php/s/OCqVQ55Q3bjzs7x)
 * [SIMPLE Grid Specification Document (Early draft)](https://docs.google.com/document/d/1yp_96UXcwNO49cktnHtT61iNmTO0RgrSQukuNYqACpM/edit#heading=h.3etse5r12l7p)
 * [WLCG](http://wlcg.web.cern.ch/)
-* [Introduction to WLCG](http://litmaath.web.cern.ch/litmaath/grids-intro/WLCG-intro-2019-v4.pdf)
 * [Introduction to WLCG Lightweight Sites](https://indico.jinr.ru/contributionDisplay.py?contribId=219&confId=151)
 

--- a/_gsocproposals/2020/proposal_Phoenix.md
+++ b/_gsocproposals/2020/proposal_Phoenix.md
@@ -13,7 +13,7 @@ organization:
 
 Visualising HEP event data is currently typically done per experiment (e.g. [VP1](http://atlas-vp1.web.cern.ch/atlas-vp1/home/), [Iguana](https://doi.org/10.1016/j.nima.2004.07.036), [Fireworks](https://iopscience.iop.org/article/10.1088/1742-6596/219/3/032014/pdf)), and normally involves the installation of dedicated software. However modern browsers are more than capable of showing complex detector geometry, as well as representations of the underlying physics. As the [Visualisation](https://arxiv.org/abs/1811.10309) section of HSF Community White Paper explained, using an intermediate data format (e.g. JSON) makes it possible to separate the event display from the underlying (experiment-specific) software framework. 
 
-[Phoenix](https://hepsoftwarefoundation.org/phoenix/) is a framework that can be used by any typical (e.g. colliding beam) High Energy Physics experiment. It was initially based on work done for the TrackML [Kaggle](https://www.kaggle.com/c/trackml-particle-identification)/[Codalab](https://competitions.codalab.org/competitions/20112) challenges (and internal use by ATLAS). We were working with a GSOC student in 2019 who ported it to [angular](https://angular.io), and added new functionality (such as overlays, compound objects etc). A [LHCb example](http://hepsoftwarefoundation.org/phoenix/lhcb) has since been added, so the underlying principle is well validated, and various "loaders" exist to read JSON, Atlas JiveXML, LHCb and TrackML event data. The task now is to make it more user friendly, and to add more functionality.
+[Phoenix](https://hepsoftwarefoundation.org/phoenix/) is a framework that can be used by any typical (e.g. colliding beam) High Energy Physics experiment. It was initially based on work done for the TrackML [Kaggle](https://www.kaggle.com/c/trackml-particle-identification)/[Codalab](https://competitions.codalab.org/competitions/20112) challenges (and internal use by ATLAS). We were working with a GSOC student in 2019 who ported it to [angular](https://angular.io), and added new functionality (such as overlays, compound objects etc). A [LHCb example](https://hepsoftwarefoundation.org/phoenix/lhcb) has since been added, so the underlying principle is well validated, and various "loaders" exist to read JSON, Atlas JiveXML, LHCb and TrackML event data. The task now is to make it more user friendly, and to add more functionality.
 
 ## Task ideas
  * Develop a better GUI (using open source tools). VP1 is a possible example of what should be aimed for.
@@ -25,7 +25,7 @@ Visualising HEP event data is currently typically done per experiment (e.g. [VP1
  * Further tests etc to improve code quality
  * New visualisation techniques, such as projects into a calorimeter cluster plan.
  * Animation of events
- * Improve the [VR playground](http://hepsoftwarefoundation.org/phoenix/playgroundVR)
+ * Improve the [VR playground](https://hepsoftwarefoundation.org/phoenix/playgroundVR)
 
 ## Expected results
 A more intuitive interface to allow complex object selection and visualisation, possibility to animate the events (primarily for outreach and public relations purposes). Better functionality and the ability to display events in "real time". 

--- a/_gsocproposals/2020/proposal_Phoenix.md
+++ b/_gsocproposals/2020/proposal_Phoenix.md
@@ -9,11 +9,13 @@ organization:
   - CERN
 ---
 
+<!-- Phoenix visualisation URLs can't be validated by the checker, for some reason -->
+
 ## Description
 
 Visualising HEP event data is currently typically done per experiment (e.g. [VP1](http://atlas-vp1.web.cern.ch/atlas-vp1/home/), [Iguana](https://doi.org/10.1016/j.nima.2004.07.036), [Fireworks](https://iopscience.iop.org/article/10.1088/1742-6596/219/3/032014/pdf)), and normally involves the installation of dedicated software. However modern browsers are more than capable of showing complex detector geometry, as well as representations of the underlying physics. As the [Visualisation](https://arxiv.org/abs/1811.10309) section of HSF Community White Paper explained, using an intermediate data format (e.g. JSON) makes it possible to separate the event display from the underlying (experiment-specific) software framework. 
 
-[Phoenix](https://hepsoftwarefoundation.org/phoenix/) is a framework that can be used by any typical (e.g. colliding beam) High Energy Physics experiment. It was initially based on work done for the TrackML [Kaggle](https://www.kaggle.com/c/trackml-particle-identification)/[Codalab](https://competitions.codalab.org/competitions/20112) challenges (and internal use by ATLAS). We were working with a GSOC student in 2019 who ported it to [angular](https://angular.io), and added new functionality (such as overlays, compound objects etc). A [LHCb example](https://hepsoftwarefoundation.org/phoenix/lhcb) has since been added, so the underlying principle is well validated, and various "loaders" exist to read JSON, Atlas JiveXML, LHCb and TrackML event data. The task now is to make it more user friendly, and to add more functionality.
+[Phoenix](https://hepsoftwarefoundation.org/phoenix/) is a framework that can be used by any typical (e.g. colliding beam) High Energy Physics experiment. It was initially based on work done for the TrackML [Kaggle](https://www.kaggle.com/c/trackml-particle-identification)/[Codalab](https://competitions.codalab.org/competitions/20112) challenges (and internal use by ATLAS). We were working with a GSOC student in 2019 who ported it to [angular](https://angular.io), and added new functionality (such as overlays, compound objects etc). A [LHCb example](https://hepsoftwarefoundation.org/phoenix/lhcb){:data-proofer-ignore=""} has since been added, so the underlying principle is well validated, and various "loaders" exist to read JSON, Atlas JiveXML, LHCb and TrackML event data. The task now is to make it more user friendly, and to add more functionality.
 
 ## Task ideas
  * Develop a better GUI (using open source tools). VP1 is a possible example of what should be aimed for.
@@ -25,7 +27,7 @@ Visualising HEP event data is currently typically done per experiment (e.g. [VP1
  * Further tests etc to improve code quality
  * New visualisation techniques, such as projects into a calorimeter cluster plan.
  * Animation of events
- * Improve the [VR playground](https://hepsoftwarefoundation.org/phoenix/playgroundVR)
+ * Improve the [VR playground](https://hepsoftwarefoundation.org/phoenix/playgroundVR){:data-proofer-ignore=""}
 
 ## Expected results
 A more intuitive interface to allow complex object selection and visualisation, possibility to animate the events (primarily for outreach and public relations purposes). Better functionality and the ability to display events in "real time". 

--- a/_includes/list_of_schools.md
+++ b/_includes/list_of_schools.md
@@ -10,9 +10,9 @@
   {% capture date %}{{post.end_date | date: '%s' }}{% endcapture %}
   {% if date > now %}
   {% if post.deadline != blank %}
-  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} - **Deadline:** {{post.deadline | date: "%-d %b %Y"}} ]({{post.source}})
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} - **Deadline:** {{post.deadline | date: "%-d %b %Y"}} ]({{post.source}}){% if post.url_proof_ignore %}{:data-proofer-ignore=""}{% endif %}
   {% else %}
-  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}}){% if post.url_proof_ignore %}{:data-proofer-ignore=""}{% endif %}
   {% endif %}
   {% endif %}
 {% endfor %}
@@ -21,6 +21,6 @@
 {% for post in schools reversed %}
   {% capture date %}{{post.end_date | date: '%s' | plus: 0 }}{% endcapture %}
   {% if date < now %}
-  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}}){% if post.url_proof_ignore %}{:data-proofer-ignore=""}{% endif %}
   {% endif %}
 {% endfor %}

--- a/_workinggroups/pyhep.md
+++ b/_workinggroups/pyhep.md
@@ -100,7 +100,7 @@ The first workshop, **PyHEP 2018**, was held as a pre-CHEP event in Sofia, Bulga
 The workshop was a forum for the participants, representatives of the community, to discuss topics around the areas of work identified in the HSF [Community White Paper](/activities/cwp.html). There was ample time for discussion.
 
 A keynote presentation on [JupyterLab](http://jupyterlab.readthedocs.io/){:target="_pyhep2018_jupyterlab"}
-was given by [Vidar Tonaas Fauske](https://www.simula.no/people/vidar){:target="_pyhep2018_vidar"}.
+was given by Vidar Tonaas Fauske.
 
 The [agenda](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"} was composed of plenary sessions dedicated to the following topics:
 

--- a/_workinggroups/toolsandpackaging.md
+++ b/_workinggroups/toolsandpackaging.md
@@ -60,7 +60,7 @@ Documentation for these *test drive* setups is in the group's
 
 The group is currently coordinated by Ben Morgan (Warwick, ATLAS and superNEMO), Alaettin Serhan Mete (Argonne National Laboratory, ATLAS), and Martin Ritter (LMU Munich, Belle II).
 
-*  The Indico pages for the working group meetings can be found at <https://indico.cern.ch/category/10415/> and <https://indico.cern.ch/category/7975/> (to be merged)
+*  The Indico pages for the working group meetings can be found at <https://indico.cern.ch/category/7975/>
 *  All coordinators can be reached at <hsf-software-tools-wg-conveners@googlegroups.com>
 *  For all technical discussions please use <hsf-tech-forum@googlegroups.com> (Tools) and <hsf-packaging-wg@googlegroups.com> (Packaging)
 

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -52,9 +52,9 @@ The [HSF-Training GitHub Organization](https://github.com/hsf-training) has [Ana
   {% capture date %}{{post.end_date | date: '%s' }}{% endcapture %}
   {% if date > now %}
   {% if post.deadline != blank %}
-  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} - **Deadline:** {{post.deadline| date: "%-d %b %Y"}} ]({{post.source}})
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} - **Deadline:** {{post.deadline| date: "%-d %b %Y"}} ]({{post.source}}){% if post.url_proof_ignore %}{:data-proofer-ignore=""}{% endif %}
   {% else %}
-  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}})
+  1. [**{{post.date | date: "%-d %b"}} - {{post.end_date | date: "%-d %b %Y"}}** - {{post.title}} ]({{post.source}}){% if post.url_proof_ignore %}{:data-proofer-ignore=""}{% endif %}
   {% endif %}
   {% endif %}
 {% endfor %}

--- a/announcements/_posts/2020-01-07-gsoc.md
+++ b/announcements/_posts/2020-01-07-gsoc.md
@@ -3,7 +3,7 @@ title: HSF GSoC 2020 call for projects and mentors
 author: Andrei Gheata
 layout: newsletter
 symbol: glyphicon-calendar
-link: activities/gsoc.html
+link: /activities/gsoc.html
 until: 2020-02-05
 ---
-[HSF GSoC 2020 call](activities/gsoc.html)
+[HSF GSoC 2020 call](/activities/gsoc.html)

--- a/archive/tracking.md
+++ b/archive/tracking.md
@@ -40,7 +40,8 @@ We invite interested projects and groups to participate and will list them on th
 
 ## Related Workshops
 
-  * [Connecting the Dots 2016](https://indico.hephy.oeaw.ac.at/event/86/)
+<!-- HEP PY Indico has regular timeout issues -->
+  * [Connecting the Dots 2016](https://indico.hephy.oeaw.ac.at/event/86/){:data-proofer-ignore=""}
   * [Connecting the Dots 2015](https://indico.physics.lbl.gov/indico/conferenceDisplay.py?confId=149)
 
 

--- a/archive/tracking.md
+++ b/archive/tracking.md
@@ -28,7 +28,7 @@ We have two mailing lists for exchange of information and technical discussions
 {:.table .table-hover .table-condensed .table-striped}
 | Date                                                                               | Main topic                          |
 | ---------------------------------------------------------------------------------- | ----------------------------------- |
-| [24.2.2016](https://indico.hephy.oeaw.ac.at/event/86/session/5/?slotId=0#20160224) | Session at Connecting the Dots 2016 |
+| [24.2.2016](https://indico.hephy.oeaw.ac.at/event/86/session/5/?slotId=0#20160224){:data-proofer-ignore=""} | Session at Connecting the Dots 2016 |
 | [29.1.2016](https://indico.cern.ch/event/486488/)                                  | Vidyo Meeting                       |
 | [3.12.2015](https://indico.cern.ch/event/459865/)                                  | Kickoff Meeting at CERN             |
 

--- a/organization/_posts/2016/2016-02-18-startup.md
+++ b/organization/_posts/2016/2016-02-18-startup.md
@@ -58,7 +58,7 @@ maintenance. On going discussion with Marco Cattaneo.
 - Next week Torre will probably make an update.
 
 ## AOB
-- Reminding the Connecting the [dots workshop](https://indico.hephy.oeaw.ac.at/event/86/) next week. 
+- Reminding the Connecting the [dots workshop](https://indico.hephy.oeaw.ac.at/event/86/){:data-proofer-ignore=""} next week. 
   Contributions form various parts are expected. People should be able to connect remotely. Send a reminder mail.
 
 

--- a/organization/_posts/2016/2016-02-25-startup.md
+++ b/organization/_posts/2016/2016-02-25-startup.md
@@ -14,7 +14,7 @@ Present: Torre, Andrea, Dario, Michel, Pere, Liz, David Rousseau
 - Pere is invited to JLab in March, an NP computing futures workshop, to present a talk on ROOT. Will mention HSF in the presentation. (Amber sent an announcement of the workshop.)
 - this meeting is rebranded as the 'HSF weekly meeting' (note the new indico page description)
 - [DIANA project](http://diana-hep.org) announced
-- [Connecting the Dots workshop](https://indico.hephy.oeaw.ac.at/event/86/) taking place this week, news next week
+- [Connecting the Dots workshop](https://indico.hephy.oeaw.ac.at/event/86/){:data-proofer-ignore=""} taking place this week, news next week
 
 Discussed approaches to git workflow to maintain the website. For code, the pull request/merge workflow is high value and essential for collaborative work, for our website where updates can consist of e.g. one person writing and posting/revising meeting minutes it is less obvious, but the pull req/merge workflow should be welcome (and the single-contributor push workflow for the simplest cases should be tolerated).
 

--- a/organization/_posts/2016/2016-05-04-Workshop-summary.md
+++ b/organization/_posts/2016/2016-05-04-Workshop-summary.md
@@ -483,7 +483,7 @@ Keras: Python library interfacing with tensor manipulation frameworks like Tenso
 
 In ATLAS:
 
--   Keras-trained RNNs for flavor tagging already in Athena ([*RNNIPTag*](https://svnweb.cern.ch/trac/atlasoff/browser/PhysicsAnalysis/JetTagging/JetTagTools/trunk/src/RNNIPTag.cxx)) based on lightweight NN class ([*lwtnn*](https://github.com/dguest/lwtnn))
+-   Keras-trained RNNs for flavor tagging already in Athena *RNNIPTag* based on lightweight NN class ([*lwtnn*](https://github.com/dguest/lwtnn))
 
 -   Ongoing work to try to integrate TensorFlow with Athena
 

--- a/organization/_posts/2018/2018-02-08-startup.md
+++ b/organization/_posts/2018/2018-02-08-startup.md
@@ -16,7 +16,7 @@ News, general matters
         collaboration, legal and economics within the scope of FOSS".
     -   Not immediately clear if this would be actually interesting for
         us, although the related [Berlin
-        Buzzwords](https://berlinbuzzwords.de/18/about)
+        Buzzwords](https://berlinbuzzwords.de/)
         event does seem well established (open source big data
         conference).
     -   Apache Foundation are an event partner (does this make it more

--- a/organization/_posts/2019/2019-07-11-coordination.md
+++ b/organization/_posts/2019/2019-07-11-coordination.md
@@ -116,8 +116,8 @@ Update slides [<span class="underline">attached to agenda</span>](https://indico
 #### Planned meetings
   - Next week (July 17th): joint discussion on partial event building
     for real-time analysis within Institut Pascal
-    [<span class="underline">“Learning To Discover”
-    workshop</span>](https://www.universite-paris-saclay.fr/fr/real-time-workshop)
+    <span class="underline">“Learning To Discover”
+    workshop</span> https://www.universite-paris-saclay.fr/fr/real-time-workshop
     (agenda tba today)
   - July 31st: [<span class="underline">joint ACTS
     meeting</span>](https://indico.cern.ch/event/830160/)

--- a/organization/_posts/2019/2019-11-21-coordination.md
+++ b/organization/_posts/2019/2019-11-21-coordination.md
@@ -233,9 +233,6 @@ Sexton-Kennedy</span>
             public park.</span>
       - <span dir="ltr">Full description of two locations here:
         [<span class="underline">https://docs.google.com/document/d/1lLLA4NqyCa5MpYJVseflX-LiHwKFu3CvDp5j\_83PgAM/edit?usp=sharing</span>](https://docs.google.com/document/d/1lLLA4NqyCa5MpYJVseflX-LiHwKFu3CvDp5j_83PgAM/edit?usp=sharing)</span>
-      - <span dir="ltr">Maybe we can have a show-of-hands here as
-        well?</span>
-          - <span dir="ltr">[<span class="underline">https://indico.cern.ch/event/860332/</span>](https://indico.cern.ch/event/860332/)</span>
       - <span dir="ltr">Opinions to:
         [<span class="underline">wlcg-hsf-workshop-2020-organisation@cern.ch</span>](mailto:wlcg-hsf-workshop-2020-organisation@cern.ch)</span>
 

--- a/organization/_posts/2020/2020-02-13-coordination.md
+++ b/organization/_posts/2020/2020-02-13-coordination.md
@@ -138,7 +138,7 @@ The workshop fee will be:
 
 The conference dinner, prepared with local ingredients and hosted at the Lund Grand Hotel, can also be paid from the payment page (approx. 50 EUR).
 
-There is a [poster](https://indico.cern.ch/event/867789/attachments/1984157/3309134/Poster_HSFWLCG.pdf) on the website - please print and pin up!
+There is a poster on the website - please print and pin up!
 
 #### Scientific Programme
 

--- a/organization/_posts/2020/2020-02-27-coordination.md
+++ b/organization/_posts/2020/2020-02-27-coordination.md
@@ -152,7 +152,7 @@ Workshop registration is open:
 
 <https://indico.cern.ch/event/867789/>
 
-There is a [poster](https://indico.cern.ch/event/867789/attachments/1984157/3309134/Poster_HSFWLCG.pdf) on the website - please print and pin up! (CERN: B40, B32, B2, B1 and R1 fairly well covered - can someone do R2 and IT buildings?)
+There is a [poster](https://indico.cern.ch/event/867789/attachments/1984157/3312033/Poster_HSFWLCG.pdf) on the website - please print and pin up! (CERN: B40, B32, B2, B1 and R1 fairly well covered - can someone do R2 and IT buildings?)
 
 #### Scientific Programme
 


### PR DESCRIPTION
Trawled through all broken URLs on the site and redirected, disabled or just removed them, as necessary.

There is still an issue with the `rucio.cern.ch` certificate, that required manual patching in the docker image (<https://github.com/HSF/docker>). New image was pushed to docker hub, so should be running fine now.

Fixes #613 

Just to prove it worked:

```
Running ["ImageCheck", "HtmlCheck", "LinkCheck", "ScriptCheck"] on ["./_site"] on *.html... 

Checking 1537 external links...
Ran on 792 files!

HTML-Proofer finished successfully.
```
