### PR TITLE
fixing mentor list for Brown U projects

### DIFF
--- a/_gsocproposals/2020/proposal_DEEPLENSE.md
+++ b/_gsocproposals/2020/proposal_DEEPLENSE.md
@@ -32,6 +32,7 @@ Python, C++, and some previous experience in Machine Learning.
   * [Michael Toomey](mailto:michael_toomey@brown.edu)
   * [Stephon Alexander](mailto:stephon_alexander@brown.edu)
   * [Sergei Gleyzer](mailto:Sergei.Gleyzer@cern.ch)
+  * [Emanuele Usai](mailto:emanuele.usai@cern.ch) 
 
 Please DO NOT contact mentors directly by email, and instead please send project inquiries to MLSFT-GSOC@cern.ch with Project Title in the subject and relevant mentors will get in touch with you. 
 

--- a/_gsocproposals/2020/proposal_E2E.md
+++ b/_gsocproposals/2020/proposal_E2E.md
@@ -34,8 +34,9 @@ This project will focus on the integration of E2E code with the [CMSSW](https://
 Python, Keras, PyTorch, C++, and some previous experience in Machine Learning.
 
 ## Mentors
-  * [Mujeon Kim](mailto:pq8556@ufl.edu) 
-  * [Sergei Gleyzer](mailto:Sergei.Gleyzer@cern.ch) 
+  * [Sergei Gleyzer](mailto:Sergei.Gleyzer@cern.ch)
+  * [Michael Andrews](mailto:michael.andrews@cern.ch)
+  * [Emanuele Usai](mailto:emanuele.usai@cern.ch)   
 
 Please DO NOT contact mentors directly by email, and instead please send project inquiries to MLSFT-GSOC@cern.ch with Project Title in the subject and relevant mentors will get in touch with you. 
 

--- a/_gsocproposals/2020/proposal_FALCON.md
+++ b/_gsocproposals/2020/proposal_FALCON.md
@@ -8,6 +8,7 @@ organization:
  - FSU
  - Alabama
  - OProject
+ - Brown
 ---
 
 ## Description
@@ -27,9 +28,9 @@ Strong development skills, good knowledge of C++ and Python. Interest in Machine
   * [Harrison Prosper](mailto:sft-gsoc-ml@googlegroups.com?subject=FALCON)
   * [Sergei Gleyzer](mailto:sft-gsoc-ml@googlegroups.com?subject=FALCON)
   * [Sitong An](mailto:sft-gsoc-ml@googlegroups.com?subject=FALCON)
+  * [Emanuele Usai](mailto:sft-gsoc-ml@googlegroups.com?subject=FALCON) 
 
 Please DO NOT contact mentors directly by email, and instead please send project inquiries to MLSFT-GSOC@cern.ch with Project Title in the subject and relevant mentors will get in touch with you. 
 
 ## Links
   * [FALCON paper](http://inspirehep.net/record/1456803)
-  * [http://root.cern](http://root.cern)

--- a/gsoc/2020/mentors.md
+++ b/gsoc/2020/mentors.md
@@ -9,6 +9,7 @@ layout: plain
 * Stephon Alexander [stephon_alexander@brown.edu ](mailto:stephon_alexander@brown.edu ) Brown University
 * Guilherme Amadio [amadio@cern.ch](mailto:amadio@cern.ch) CERN
 * Sitong An [s.an@cern.ch](mailto:s.an@cern.ch) CERN
+* Michael Andrews [michael.andrews@cern.ch](mailto:michael.andrews@cern.ch) CERN
 * Christian Ariza [christian.ariza@gmail.com](mailto:christian.ariza@gmail.com) CERN
 * Chris Arnault [arnault@lal.in2p3.fr](mailto:arnault@lal.in2p3.fr) IJCLab
 * Martin Barisits [martin.barisits@cern.ch](mailto:martin.barisits@cern.ch) CERN
@@ -79,7 +80,7 @@ layout: plain
 * Shaojun Sun [shaojun.sun@cern.ch](mailto:shaojun.sun@cern.ch) University of Wisconsin-Madison
 * Enric Tejedor [etejedor@cern.ch](mailto:etejedor@cern.ch) CERN
 * Michael Toomey [michael_toomey@brown.edu](mailto:michael_toomey@brown.edu) Brown University
-* Emanuele Usai [Emanuele.Usai@cern.ch ](mailto:Emanuele.Usai@cern.ch ) Brown University
+* Emanuele Usai [Emanuele.Usai@cern.ch](mailto:Emanuele.Usai@cern.ch) Brown University
 * Andrea Valassi [andrea.valassi@cern.ch](mailto:andrea.valassi@cern.ch) CERN
 * Akshay Vashistha [Akshay Vashistha](mailto:akshayvashistha1995@gmail.com) OProject
 * Vassil Vassilev [vvasilev@cern.ch](mailto:vvasilev@cern.ch) Princeton University


### PR DESCRIPTION
This pull request fixes the mentor list and links for projects by BrownU, as agreed with Sergei Gleyzer. 

-- E2E project:
add myself and Michael A., remove Mujeon.
-- DeepLens project:
add myself.
-- Falcon project:
Add myself, add Brown as institution, remove link to root in the references.