### PR TITLE
Add note on training events with un-validatable URLs

### DIFF
--- a/howto-website.md
+++ b/howto-website.md
@@ -83,6 +83,10 @@ entry you can either:
 
 1. Run the interactive script ``scripts/add_training_event.py`` (recommended)
 2. Directly edit the ``_data/trainning-schools.yml`` file and add another entry following the structure of the existing entries (note that events are sorted chronologically by starting date)
+    - There is one very rare thing you may need to do if the URL for the training event 
+      will not validate in the link checker, which is to add the tag `url_proof_ignore: true`
+      to the YAML file (an example is a school that used a web technology that insists
+      on setting cookies and issues continual redirects without this)
 
 ### Adding news or announcements
 


### PR DESCRIPTION
@klieret - this issue came up with the Trans-Siberian School when I was fixing all of the persistent bad links in #736.

Note the supporting changes that were made:

- <https://github.com/HSF/hsf.github.io/pull/736/files#diff-86ad63be0256d177ec9de64b737d3e8b>
- <https://github.com/HSF/hsf.github.io/pull/736/files#diff-7f814d9e5bdc111dc5c9cb827af272a7>