### PR TITLE
Improve website link reliability

### DIFF
--- a/.travis-scripts/html-proofer
+++ b/.travis-scripts/html-proofer
@@ -17,6 +17,9 @@ then
 fi
 
 # DESY Debug statetments
+echo NETWORK
+ifconfig -a
+echo
 echo HTTP HEADER TEST
 curl -I -L https://indico.desy.de/indico/
 echo 

--- a/.travis-scripts/html-proofer
+++ b/.travis-scripts/html-proofer
@@ -16,6 +16,14 @@ then
     usage
 fi
 
+# DESY Debug statetments
+echo HTTP HEADER TEST
+curl -I -L https://indico.desy.de/indico/
+echo 
+echo HTTP PAGE TEST
+curl -L https://indico.desy.de/indico/event/22731/
+# End
+
 bundle exec jekyll build
 bundle exec htmlproofer ${url_ignore_option} ${debug_option} --check-html ./_site
 status=$?

--- a/_gsocproposals/2018/proposal_DIANAHEPanalysisfunctions.md
+++ b/_gsocproposals/2018/proposal_DIANAHEPanalysisfunctions.md
@@ -19,7 +19,7 @@ The proposed project would be to develop a suite of HEP analysis primitive funct
 We propose the following steps:
 
  * given a collection of real-world analysis scripts and explanations of their purpose, distill the common techniques into components that can be composed;
- * express these components in frameworks like [Object-Array Mapping](https://github.com/diana-hep/oamap), which allows rapid exchange between object-oriented views and vectorizable-array views of the same data, or [Histogrammar](http://histogrammar.org), which builds plots by composition, or a new, similar infrastructure;
+ * express these components in frameworks like [Object-Array Mapping](https://github.com/diana-hep/oamap), which allows rapid exchange between object-oriented views and vectorizable-array views of the same data, or [Histogrammar](https://pypi.org/project/histogrammar/), which builds plots by composition, or a new, similar infrastructure;
  * demonstrate that the original analysis code can be expressed as compositions of these components, hopefully reducing complexity and improving readability;
  * run performance tests on the original and re-expressed scripts, hopefully observing an improvement.
 

--- a/_gsocproposals/2018/proposal_DIANAHEPanalysisfunctions.md
+++ b/_gsocproposals/2018/proposal_DIANAHEPanalysisfunctions.md
@@ -41,4 +41,4 @@ At the end of this project, we expect a first draft of a functional/pipelined/ve
 ## Links
 
   * [Object-Array Mapping](https://github.com/diana-hep/oamap)
-  * [Histogrammar](http://histogrammar.org)
+  * [Histogrammar](https://pypi.org/project/histogrammar/)

--- a/_gsocproposals/2020/proposal_CVMFSPodmanIntegration.md
+++ b/_gsocproposals/2020/proposal_CVMFSPodmanIntegration.md
@@ -113,4 +113,4 @@ The code-base will mostly be in Go(lang), hence it is necessary to know the lang
 [simo]: mailto:simone.mosciatti@cern.ch
 [ducc]: https://github.com/cvmfs/cvmfs/tree/devel/ducc
 [docker-graphdriver]: https://cvmfs.readthedocs.io/en/stable/cpt-graphdriver.html
-[remote-containerd]: https://github.com/ktock/stargz-snapshotter/pull/27
+[remote-containerd]: https://github.com/ktock/stargz-snapshotter/

--- a/_includes/events.ext
+++ b/_includes/events.ext
@@ -11,5 +11,3 @@
   {% endfor %}
 
   </ul>
-
-See also <a href="http://hepsoftware.org/?popupmode=Events&amp;popupstate=events">HEP S&amp;C community events</a>

--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -45,7 +45,6 @@
                   <li><a href="/newsletter.html">Newsletters</a></li>
                   <li class="divider"></li>
                   <li><a href="/inventory/inventory.html">HSF Project Inventory</a></li>
-                  <li><a href="http://www.hepsoftware.org">HEP S&amp;C Knowledge Base</a></li>
                 </ul>
             </li>
             <li class="dropdown">

--- a/_includes/sidebar.ext
+++ b/_includes/sidebar.ext
@@ -17,7 +17,6 @@ contact the <a href="mailto:hsf-coordination@googlegroups.com">startup team</a>.
       {% endif %}
     {% endfor %}
     </ol>
-See also <a href='http://hepsoftware.org/?popupmode=Events&popupstate=events'>HEP S&amp;C community events</a>
   </div>
 
   <div class="sidebar-module sidebar-module-inset">
@@ -35,7 +34,6 @@ See also <a href='http://hepsoftware.org/?popupmode=Events&popupstate=events'>HE
     <h4>Links</h4>
     <ol class="list-unstyled">
       <li><a href="http://feeds.feedburner.com/HepSoftwareFoundationNewsletter">RSS feed</a></li>
-      <li><a href="http://hepsoftware.org">HEP Knowledge Base</a></li>
       <li><a href="http://it.wikitolearn.org/Main_HSF_Page">HSF on WikiToLearn</a></li>
       <li><a href="https://github.com/HSF">HSF on GitHub</a></li>
 

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -84,9 +84,8 @@ in High Energy Physics software and computing internationally.
     	<p>We organise many activities, from our <a href="/what_are_WGs.html">working groups</a>,
           to organising <a href="/events.html">events</a>, to supporting projects as
           <a href="/projects.html">HSF projects</a>, and helping communication within the
-          community through our  <a href="/forums.html">discussion forums</a>,
-          <a href="/technical_notes.html">technical notes</a> and a
-          <a href="http://www.hepsoftware.org/">knowledge base</a>.
+          community through our  <a href="/forums.html">discussion forums</a>
+          and <a href="/technical_notes.html">technical notes</a>.
           </p>
    <p><a href="/get_involved.html" role="button">How to get involved &raquo;</a></p>
        </div>

--- a/_training/module-guidelines.md
+++ b/_training/module-guidelines.md
@@ -7,7 +7,7 @@ layout: plain
 The training material should aim at and be relevant for the HEP community.
 
 ## Format of the training modules
-We are a fan of developing training modules similar to the work of the [software carpentry](software-carpentry.org): as a git repository containing a set of markdown files together with nice tooling to display them as fancy webpages. This format makes it easy to collaboratively extend and maintain the modules.
+We are a fan of developing training modules similar to the work of the [software carpentry](https://software-carpentry.org): as a git repository containing a set of markdown files together with nice tooling to display them as fancy webpages. This format makes it easy to collaboratively extend and maintain the modules.
 
 We are also open for other formats as well (suggestions are always welcome), if they are
 

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -39,7 +39,7 @@ Weekly meetings are usually held at 15h30 CERN time on Mondays. Everyone is welc
 
 ## Towards a full HEP Software Curriculum
 
-Our long term goal is to compile standardized HEP Software training modules into a full curriculum. More about this project can be found [here](/training/curriculum).
+Our long term goal is to compile standardized HEP Software training modules into a full curriculum. More about this project can be found [here](/training/curriculum.html).
 
 ## Github Organization
 

--- a/inventory/inventory.md
+++ b/inventory/inventory.md
@@ -5,11 +5,9 @@ layout: default
 
 # Community Projects
 
-The HSF is currently compiling an inventory of community software projects.
-
-For the moment we continue to gather information on projects as part of
-the [HEP Software and Computing Knowldge Base](http://www.hepsoftware.org/?popupmode=Software&popupstate=cat).
+The HSF helps to compile an inventory of community software projects.
 
 If you know of a particularly useful or critical software package then
-please [add it to the knowledge base](http://hepsoftware.org/?e=wenaus.201510251113185035029&detailmode=Entity&detailstate=on)
-or [let us know about it](mailto:hsf-coordination@googlegroups.com).
+please let us know about it, by contacting the appropriate
+[Working Group Convenors](/what_are_WGs.html) or
+[HSF Coordinators](mailto:hsf-coordination@googlegroups.com).

--- a/newsletter/_posts/2015-11-30-KB.md
+++ b/newsletter/_posts/2015-11-30-KB.md
@@ -26,29 +26,27 @@ way using [GitHub Pages](https://pages.github.com/).
 
 ## The HEP Software & Computing Knowledge Base
 
-<img src="http://www.hepsoftware.org/sw/static/hepsoftware-logo-white-400.jpg" alt="HEP S&C Knowledge Base Logo" width="200">
-
-The High Energy Physics (HEP) Software & Computing [Knowledge Base](https://en.wikipedia.org/wiki/Knowledge_base) (KB) at [hepsoftware.org](http://hepsoftware.org) is a collection point for HEP related software projects and information on HEP software and computing. You can use it to look for existing software, to make your own project known to the community, and to inform the community what software you and your experiment use.
+The High Energy Physics (HEP) Software & Computing [Knowledge Base](https://en.wikipedia.org/wiki/Knowledge_base) (KB) at http://hepsoftware.org is a collection point for HEP related software projects and information on HEP software and computing. You can use it to look for existing software, to make your own project known to the community, and to inform the community what software you and your experiment use.
 
 
 ### What kind of information is stored
 
 To take a concrete example, let's have a look at the information stored for the
-*[ROOT](http://hepsoftware.org/e/root)* package. It contains a short description
+*ROOT* http://hepsoftware.org/e/root package. It contains a short description
 of the project, pointers to support lists, repository, and other sources of
 information. In addition it links to the various users of ROOT within the knowledge
 base. All information, most of you probably know.
 However, finding that out for less well known packages is much harder. The KB provides a central collection point for such information. It also provides a way to describe relationships like who uses what.
 
 In addition to software projects, the KB contains information about
-summer schools, various events or resources related to HEP software and computing or organizations. Of course the [HSF](http://hepsoftware.org/e/hsf)
+summer schools, various events or resources related to HEP software and computing or organizations. Of course the HSF http://hepsoftware.org/e/hsf.
 is represented there as well.
 
 ### How to add new information
 
 Please feel encouraged to extend, or update the information presented in the knowledge base. Its usefulness depends on developing rich informative content. Instead of requiring user registration, you can re-use your account of either GitHub, Google, Dropbox, Amazon, or Facebook. One click of confirmation and you can immediately start adding new information.
 
-Editing itself works via clicking on the *pen icon*, typing your text in [Markdown](https://help.github.com/articles/markdown-basics/), and hitting the green save button in the header. A more detailed introduction into all the editing capabilities is given [here](http://hepsoftware.org/e/hepsoftwareorg).
+Editing itself works via clicking on the *pen icon*, typing your text in [Markdown](https://help.github.com/articles/markdown-basics/), and hitting the green save button in the header. A more detailed introduction into all the editing capabilities is given here http://hepsoftware.org/e/hepsoftwareorg.
 
 
 

--- a/newsletter/_posts/2016-05-17-workshop-lal.md
+++ b/newsletter/_posts/2016-05-17-workshop-lal.md
@@ -143,11 +143,11 @@ progress accomplished in the last year, yielding an increasing motivation.
 In addition to the initiatives already mentioned and the follow-up of existing 
 activities, the main actions agreed for the coming year are: 
 
-* HSF communication: explore the use of StackExchange, a well-identified open forum, for questions about HEP computing
-   * At some point it may become an attractive alternative for (some) mailing-list based forums in HSF
-* Increase software project support, develop project peer-review activity
-* Look for an official blessing of the HSF by bodies like ECFA/ICFA
-* Find some dedicated resources for the HSF work (currently best effort by motivated people on their "spare" time!). A proposal of creating HSF Centers in our laboratories/universities/institutions has been made: this could become visible parts of HSF hosted by various parties.
+* HSF communication: explore the use of StackExchange, a well-identified open forum, for questions about HEP computing
+  * At some point it may become an attractive alternative for (some) mailing-list based forums in HSF
+* Increase software project support, develop project peer-review activity
+* Look for an official blessing of the HSF by bodies like ECFA/ICFA
+* Find some dedicated resources for the HSF work (currently best effort by motivated people on their "spare" time!). A proposal of creating HSF Centers in our laboratories/universities/institutions has been made: this could become visible parts of HSF hosted by various parties.
 
 We also discussed (again!) the possibility of a legal entity to support HSF. Despite not reaching a consensus yet, we agreed to further explore the possibility with funding agencies and lawyers. The general idea was that this entity, if created, should focus initially on IPR management, in a way similar to the Apache Software Foundation, to make possible IPR transfer.
 

--- a/newsletter/_posts/2016-05-17-workshop-lal.md
+++ b/newsletter/_posts/2016-05-17-workshop-lal.md
@@ -31,7 +31,7 @@ time to submit a logo proposal.
 We had a session dedicated to some of the HSF SW projects and related initiatives
 * [AIDA2020 WP3](http://aida2020.web.cern.ch/activities/wp3-advanced-software): the software work package of the EU-funded project about detector R&D. AIDA2020 expressed that they want to put their development under the HSF umbrella.
 * [Next Generation Conditions Database](https://github.com/HSF/PhysCondDB): a project started jointly by CMS and ATLAS that is becoming attractive to others. This project benefits from the collaborative spirit resulting from the HSF.
-* [The HEP Software and Computing Knowledge Base](http://hepsoftware.org/): this is a project started by the HSF to facilitate software sharing. It is easy to use and allows crosslinking of software, experiments, organisations, events... **Register your favorite software!**
+* The HEP Software and Computing Knowledge Base: this is a project started by the HSF to facilitate software sharing. It is easy to use and allows crosslinking of software, experiments, organisations, events... **Register your favorite software!**
 * [WikiToLearn](https://en.wikitolearn.org/Main_Page): a new platform allowing the sharing and improving of training materials through collaboration between authors and users. Developed in Italy (University of Milano), its developers are committed to making it useful for, and usable by the HSF.
 * [DIANA-HEP](http://diana-hep.org/) (Data Intensive Analysis for HEP): a NSF-funded project to promote common analysis tools for data intensive research in HEP, using ROOT at its core. This US project shares many goals with the HSF.
 

--- a/organization/_posts/2015/2015-11-05-startup.md
+++ b/organization/_posts/2015/2015-11-05-startup.md
@@ -56,7 +56,7 @@ Andrew - recommend that WLCG task forces produce documents. Presently their repo
 
 Torre - KB ready to go, thanks for the input and help, especially Benedikt!
 
-[hepsoftware.org](http://hepsoftware.org)
+http://hepsoftware.org
 
 Benedikt - made newsletter draft and sent proposal for website reorganization.
 

--- a/organization/_posts/2016/2016-05-04-Workshop-summary.md
+++ b/organization/_posts/2016/2016-05-04-Workshop-summary.md
@@ -227,7 +227,7 @@ Data intensive ANAlisys for HEP: collaborative efforts around anlysis tools to m
 
 ### SW&C Knowledge Base - T. Wenaus
 
-[*http://hepsoftware.org*](http://hepsoftware.org): the last generation (hopefully the last one, works nicely!)
+http://hepsoftware.org: the last generation (hopefully the last one, works nicely!)
 
 -   Javascript app in the browser
 

--- a/organization/_posts/2016/2016-09-15-startup.md
+++ b/organization/_posts/2016/2016-09-15-startup.md
@@ -79,7 +79,7 @@ General agreement on the proposed letter: will be sent to reviewers in the next 
 
 ACTS project interested by guidelines/recommendations from HSF
 
--   Benedikt raised that it would be nice to have an idea of the choices made by projects: can this be extracted from [*http://hepsoftware.org*](http://hepsoftware.org) (SW&C KB)? Would help to understand the licensing of dependencies...
+-   Benedikt raised that it would be nice to have an idea of the choices made by projects: can this be extracted from http://hepsoftware.org (SW&C KB)? Would help to understand the licensing of dependencies...
 
 ## AOB
 

--- a/organization/_posts/2018/2018-05-24-coordination.md
+++ b/organization/_posts/2018/2018-05-24-coordination.md
@@ -87,7 +87,7 @@ HSF/WLCG Workshop Follow-up
 ===========================
 -   Practical follow ups at the HSF level
     -   Inventory of community activities
-        -   [http://www.hepsoftware.org/](http://www.hepsoftware.org/)
+        -   http://www.hepsoftware.org/
             is dormant - do we need a new "technology" (for example, a
             graph database may look as an attractive technology)? But
             re-use the information for sure. Link this to Sudhir's

--- a/organization/_posts/2018/2018-05-31-coordination.md
+++ b/organization/_posts/2018/2018-05-31-coordination.md
@@ -96,7 +96,7 @@ HSF/WLCG Workshop Follow-up
                 -   Need to translate these into a git branch that
                     people can preview.
             -   Discussed the future of
-                [http://www.hepsoftware.org/](http://www.hepsoftware.org/) -
+                http://www.hepsoftware.org/ -
                 at the moment we should keep using it, even if we
                 foresee its frontend being migrated (when effort is
                 identified).

--- a/organization/_posts/2018/2018-10-04-coordination.md
+++ b/organization/_posts/2018/2018-10-04-coordination.md
@@ -188,5 +188,5 @@ AOB
     -   Dan Katz has been a driver behind this and it looks like it
         would be well worth investigating and helping to promote.
     -   A future evolution of
-        [*http://hepsoftware.org/*](http://hepsoftware.org/) could go
+        http://hepsoftware.org/ could go
         this way?

--- a/organization/_posts/2018/2018-10-11-coordination.md
+++ b/organization/_posts/2018/2018-10-11-coordination.md
@@ -98,7 +98,7 @@ AOB
     -   Graeme - no activity in this area as far as I am aware.
     -   Is anyone interested in this topic?
         -   Dario and Pete are - Graeme will pass on contact details.
--   [http://hepsoftware.org/](http://hepsoftware.org/) has been down
+-   http://hepsoftware.org/ has been down
     for a week - tracked as a [GitHub
     issue](https://github.com/HSF/hsf.github.io/issues/390).
 

--- a/organization/_posts/2018/2018-10-18-coordination.md
+++ b/organization/_posts/2018/2018-10-18-coordination.md
@@ -131,7 +131,7 @@ CWP
 AOB
 ---
 -   HSF Logo in vector format - reminder of action on Benedikt.
--   [http://hepsoftware.org/](http://hepsoftware.org/) was fixed,
+-   http://hepsoftware.org/ was fixed,
     thanks to Torre ([GitHub
     issue](https://github.com/HSF/hsf.github.io/issues/390)).
 -   Website was restructured a bit to add the new working group stubs.

--- a/organization/_posts/2019/2019-07-11-coordination.md
+++ b/organization/_posts/2019/2019-07-11-coordination.md
@@ -177,8 +177,7 @@ Update slides [<span class="underline">attached to agenda</span>](https://indico
     announcement email will be sent next Monday or Tuesday at the
     latest.  
     \- Workshop taking place in the UK, at
-    [<span class="underline">The Cosener’s
-    House</span>](https://www.thecosenershouse.co.uk/), Abingdon.  
+    The Cosener’s House, Abingdon.  
     \- Will run 2.5 days, October 16-18.  
     \- We welcome input and suggestions from the HSF already at this
     stage.  

--- a/projects.md
+++ b/projects.md
@@ -17,11 +17,11 @@ We have been compiling a set of [project guidelines](project_guidelines.html) th
 {:.table .table-hover .table-condensed .table-striped}
 | Name  | Description | License | Contact |
 | --------| ------------- |----------|-----------|
-| [DD4hep](http://hepsoftware.org/e/dd4hep)   | Generic Detector Description toolkit for HEP  | LGPL v3 | [Markus Frank](mailto:marks.frank@cern.ch) |
-| [fads](http://hepsoftware.org/e/fads)          | FAst Detector Simulation  | BSD-3 | [Sebastien Binet](mailto:binet@cern.ch) |  
-| [Gaudi](http://hepsoftware.org/e/gaudi)          | Event data processing framework | Unk | [Marco Clemencic](mailto:marco.clemencic@cern.ch) |  
-| [HepMC3](http://hepsoftware.org/e/hepmc3) | C++ Event Record for Monte Carlo Generators | LGPL v3 | [Witek Pokorski](mailto:witold.pokorski@cern.ch) |
-| [podio](https://github.com/hegner/podio) | Event Data Model Library based on plain-old-data | GPL v3 | [Benedikt Hegner](mailto:benedikt.hegner@cern.ch) |
+| [DD4hep](https://github.com/AIDASoft/DD4hep)   | Generic Detector Description toolkit for HEP  | LGPL v3 | [Markus Frank](mailto:marks.frank@cern.ch) |
+| [fads](https://pkg.go.dev/go-hep.org/x/hep/fads?tab=doc)          | FAst Detector Simulation  | BSD-3 | [Sebastien Binet](mailto:binet@cern.ch) |  
+| [Gaudi](http://gaudi.web.cern.ch/gaudi/)          | Event data processing framework | Unk | [Marco Clemencic](mailto:marco.clemencic@cern.ch) |  
+| [HepMC3](https://gitlab.cern.ch/hepmc/HepMC3) | C++ Event Record for Monte Carlo Generators | LGPL v3 | [Witek Pokorski](mailto:witold.pokorski@cern.ch) |
+| [podio](https://github.com/AIDASoft/podio) | Event Data Model Library based on plain-old-data | GPL v3 | [Benedikt Hegner](mailto:benedikt.hegner@cern.ch) |
 | [PM4hep](https://github.com/hegner/PM4hep) | Minimal Plugin Manager | GPL v3 | [Benedikt Hegner](mailto:benedikt.hegner@cern.ch) |
-| [ROOT](http://hepsoftware.org/e/root)            | Data Analysis Framework | LGPL v2+ | [Pere Mato](mailto:pere.mato@cern.ch) |
-| [XRootD](http://hepsoftware.org/e/xrootd)     | High performance, scalable fault tolerant access to data  | LGPL v3 | [Andrew Hanushevsky](mailto:abh@stanford.edu)|
+| [ROOT](https://root.cern.ch/)            | Data Analysis Framework | LGPL v2+ | [Pere Mato](mailto:pere.mato@cern.ch) |
+| [XRootD](https://xrootd.slac.stanford.edu/)     | High performance, scalable fault tolerant access to data  | LGPL v3 | [Andrew Hanushevsky](mailto:abh@stanford.edu)|


### PR DESCRIPTION
Remove the hepsoftware.org links, has been down for quite a few weeks. We have to admit this just didn't get traction..

To be worked on: better analysis of URL failures to only really FAIL when connected to a particular PR