### PR TITLE
Add edit on github button

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,7 +22,8 @@
 <br><br>
 <hr>
 <div class="footer fixed-bottom">
-Thanks to <a href="https://pages.github.com/">GitHub Pages</a>, <a href="http://jekyllrb.com/">Jekyll</a> and <a href="http://getbootstrap.com/">Bootstrap</a>
+<a href="https://github.com/HSF/hsf.github.io/edit/master/{{ page.path }}"><i class="glyphicon glyphicon-wrench"></i> Improve this page. </a>
+Thanks to <a href="https://pages.github.com/">GitHub Pages</a>, <a href="http://jekyllrb.com/">Jekyll</a> and <a href="http://getbootstrap.com/">Bootstrap</a>.
 </div>
 
 </div> <!-- container -->


### PR DESCRIPTION
This makes it easy for people to see the markdown source and send around change proposals, even if they don't know how to do git. People who have write permission on the repo can also directly do changes through the github web interface in a seconds notice.

![image](https://user-images.githubusercontent.com/13602468/85841036-cae56080-b79d-11ea-84df-ef675888f3f7.png)
