### PR TITLE
Remove HR if no annoucement shown

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -22,10 +22,12 @@ in High Energy Physics software and computing internationally.
 <hr>
 
 <!-- Important announcements from announcements/_posts -->
+  {% assign has_announcements = false %}
   {% assign sitedate = site.time | date: "%Y-%m-%d"   %}
   {% for post in site.categories.announcements reversed %}
     {% assign stopdate = post.until | string_to_date | date: "%Y-%m-%d" %}
     {% if stopdate > sitedate %}
+    {% assign has_announcements = true %}
 <div class="row alert alert-warning">
   <p class="lead event-announce">
     <span class="glyphicon {{ post.symbol }}" aria-hidden="true"></span> {{ post.title }} (<a href="{{ post.link }}">more info</a>)
@@ -34,7 +36,9 @@ in High Energy Physics software and computing internationally.
     {% endif %}
   {% endfor %}
 
+{% if has_announcements %} 
 <hr>
+{% endif %}
 
  <!-- Various boxes with more information -->
 <div class="row">


### PR DESCRIPTION
Currently, the starting page looks like this:

![image](https://user-images.githubusercontent.com/13602468/87290179-f5ede500-c4fd-11ea-87aa-50324ac26c5b.png)

Note the double horizontal line (because there's no announcement).

This PR removes the second line if there's no announcements.

Tested locally for both cases.