### PR TITLE
Updates for DAWG convenor changes

### DIFF
--- a/_workinggroups/dataanalysis.md
+++ b/_workinggroups/dataanalysis.md
@@ -24,7 +24,7 @@ well-defined set of problems.
 [Meetings](https://indico.cern.ch/category/10914)
 [Forum](https://groups.google.com/forum/#!forum/hsf-analysis-wg)
 
-Convenors: Katya Govorkova (CERN), Allison Hall (Fermilab), Paul Laycock (Belle II), TJ Khoo (ATLAS), 
+Convenors: Katya Govorkova (LHCb), Allison Hall (CMS), Paul Laycock (Belle II), TJ Khoo (ATLAS)
 
 ---
 

--- a/_workinggroups/dataanalysis.md
+++ b/_workinggroups/dataanalysis.md
@@ -24,9 +24,9 @@ well-defined set of problems.
 [Meetings](https://indico.cern.ch/category/10914)
 [Forum](https://groups.google.com/forum/#!forum/hsf-analysis-wg)
 
-Convenors: Paul Laycock (Belle II), TJ Khoo (ATLAS), Andrea Rizzi (CMS)
+Convenors: Katya Govorkova (CERN), Allison Hall (Fermilab), Paul Laycock (Belle II), TJ Khoo (ATLAS), 
 
 ---
 
 Former Convenors:
-- Danilo Piparo (ROOT)
+- Danilo Piparo (ROOT), Andrea Rizzi (CMS)

--- a/organization/team.md
+++ b/organization/team.md
@@ -1,26 +1,25 @@
 ---
 title: "HSF Coordination Team"
-layout: default
+layout: plain
 ---
-
-# HSF Coordination Team
 
 Currently the activities within the HSF are organized by the *HSF coordination team* (formerly called the *startup team*). Following the concept of a do-ocracy active contributors to the HSF are invited to join. These are the current members of the team:
 
- * Caterina Doglioni - Lund University
- * Peter Elmer - Princeton University
- * Daniel Elvira - FNAL
- * Benedikt Hegner - CERN / Stony Brook University
- * Michel Jouvin - LAL, IN2P3
- * David Lange - Princeton University
- * Pere Mato - CERN
- * Mark Neubauer - University of Illinois
- * Eduardo Rodrigues - University of Liverpool
- * Stefan Roiser - CERN
- * Elizabeth Sexton-Kennedy - FNAL
- * Graeme Stewart - CERN
- * Andrea Valassi - CERN
- * Torre Wenaus - BNL
+* Caterina Doglioni - Lund University
+* Peter Elmer - Princeton University
+* Daniel Elvira - FNAL
+* Benedikt Hegner - CERN / Stony Brook University
+* Michel Jouvin - LAL, IN2P3
+* David Lange - Princeton University
+* Paul Laycock - BNL
+* Pere Mato - CERN
+* Mark Neubauer - University of Illinois
+* Eduardo Rodrigues - University of Liverpool
+* Stefan Roiser - CERN
+* Elizabeth Sexton-Kennedy - FNAL
+* Graeme Stewart - CERN
+* Andrea Valassi - CERN
+* Torre Wenaus - BNL
 
 The entire team can be contacted via <hsf-coordination@googlegroups.com>.
 


### PR DESCRIPTION
The `team.md` file was also linted with [markdownlint](https://github.com/DavidAnson/markdownlint).