### PR TITLE
Increase visibility of link to coordination team

### DIFF
--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -63,11 +63,11 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="/index.html" id="about_menu">About<span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="about_menu">
                 <li><a href="/get_involved.html">Get involved!</a><li>
+                <li><a href="/organization/team.html">The Coordination Team</a></li>
                 <li class="divider"></li>
                 <li><a href="/organization/goals.html">Goals of the HSF</a></li>
                 <li><a href="/organization/cwp.html">Community White Paper</a></li>
                 <li><a href="/organization/hsf-letters.html">Letters from the HSF</a></li>
-                <li><a href="/organization/team.html">The Coordination Team</a></li>
                 <li><a href="/organization/presentations.html">HSF Presentations</a></li>
                 <li><a href="/organization/youtube.html">HSF YouTube Channel</a></li>
                 <li class="divider"></li>


### PR DESCRIPTION
I think it's a bit hard to spot the link to the coordination team page. It should be a bit more prominent than it currently is IMO.

But not feeling too strongly about this either, just took me a while to find it