### PR TITLE
Update conveners for 2021

### DIFF
--- a/_workinggroups/dataanalysis.md
+++ b/_workinggroups/dataanalysis.md
@@ -29,4 +29,6 @@ Convenors: Chris Burr (LHCb), Allison Hall (CMS), TJ Khoo (ATLAS)
 ---
 
 Former Convenors:
-- Danilo Piparo (ROOT), Andrea Rizzi (CMS), Paul Laycock (Belle II),
+- Danilo Piparo (ROOT), 2019
+- Andrea Rizzi (CMS), 2019-2020
+- Paul Laycock (Belle II), 2019-2020

--- a/_workinggroups/dataanalysis.md
+++ b/_workinggroups/dataanalysis.md
@@ -24,9 +24,9 @@ well-defined set of problems.
 [Meetings](https://indico.cern.ch/category/10914)
 [Forum](https://groups.google.com/forum/#!forum/hsf-analysis-wg)
 
-Convenors: Chris Burr (LHCb), Allison Hall (CMS), Paul Laycock (Belle II), TJ Khoo (ATLAS)
+Convenors: Chris Burr (LHCb), Allison Hall (CMS), TJ Khoo (ATLAS)
 
 ---
 
 Former Convenors:
-- Danilo Piparo (ROOT), Andrea Rizzi (CMS)
+- Danilo Piparo (ROOT), Andrea Rizzi (CMS), Paul Laycock (Belle II),

--- a/_workinggroups/detsim.md
+++ b/_workinggroups/detsim.md
@@ -19,10 +19,11 @@ technologies) are an important area of work.
 The group's meeting page is [in Indico](https://indico.cern.ch/category/10916/) and
 discussions are held on the [hsf-simulation](https://groups.google.com/forum/#%21forum/hsf-simulation) list.
 
-- Convenors: Ben Morgan (ATLAS, Geant4), Kevin Pedro (CMS), Krzysztof Genser (Mu2e+Geant4)
+- Conveners: Ben Morgan (ATLAS, Geant4), Kevin Pedro (CMS), Krzysztof Genser (Mu2e, Geant4)
 - Email: [HSF Simulation WG Conveners](mailto:Ben.Morgan@warwick.ac.uk,kpedro88@gmail.com,resnegfk@gmail.com)
+### Former Conveners
 
----
-
-Former Convenors:
-- Heather Gray (ATLAS), Gloria Corti (LHCb), Philippe Canal (CMS), Witek Pokorski (Geant4)
+- Heather Gray (ATLAS), 2019
+- Gloria Corti (LHCb), 2019-2020
+- Philippe Canal (CMS), 2020
+- Witek Pokorski (Geant4), 2019-2020

--- a/_workinggroups/detsim.md
+++ b/_workinggroups/detsim.md
@@ -19,9 +19,10 @@ technologies) are an important area of work.
 The group's meeting page is [in Indico](https://indico.cern.ch/category/10916/) and
 discussions are held on the [hsf-simulation](https://groups.google.com/forum/#%21forum/hsf-simulation) list.
 
-Convenors: Gloria Corti (LHCb) <mailto:Gloria.Corti@cern.ch>, Philippe Canal (CMS) <mailto:philippe.canal@cern.ch>, Witek Pokorski (Geant4) <mailto:Witold.Pokorski@cern.ch>
+- Convenors: Ben Morgan (ATLAS, Geant4), Kevin Pedro (CMS), Krzysztof Genser (Mu2e+Geant4)
+- Email: [HSF Simulation WG Conveners](mailto:Ben.Morgan@warwick.ac.uk,kpedro88@gmail.com,resnegfk@gmail.com)
 
 ---
 
 Former Convenors:
-- Heather Gray (ATLAS)
+- Heather Gray (ATLAS), Gloria Corti (LHCb), Philippe Canal (CMS), Witek Pokorski (Geant4)

--- a/_workinggroups/frameworks.md
+++ b/_workinggroups/frameworks.md
@@ -42,12 +42,12 @@ and encouraging long term sustainability of framework software.
 The group's meeting page is [in Indico](https://indico.cern.ch/category/10287/) and
 discussions are held on the [hsf-tech-forum](https://groups.google.com/forum/#%21forum/hsf-tech-forum) list.
 
-## Convenors
+## Conveners
 
-The group convenors are:
+The group conveners are:
 
 - Chris Jones, FNAL <cdj@fnal.gov>
 - Kyle Knoepfel, FNAL <knoepfel@fnal.gov>
 - Attila Krasznahorkay, CERN <Attila.Krasznahorkay@cern.ch>
 
-[Email WG Convenors](mailto:cdj@fnal.gov,knoepfel@fnal.gov,Attila.Krasznahorkay@cern.ch)
+[Email WG Conveners](mailto:cdj@fnal.gov,knoepfel@fnal.gov,Attila.Krasznahorkay@cern.ch)

--- a/_workinggroups/frameworks.md
+++ b/_workinggroups/frameworks.md
@@ -49,3 +49,5 @@ The group convenors are:
 - Chris Jones, FNAL <cdj@fnal.gov>
 - Kyle Knoepfel, FNAL <knoepfel@fnal.gov>
 - Attila Krasznahorkay, CERN <Attila.Krasznahorkay@cern.ch>
+
+[Email WG Convenors](mailto:cdj@fnal.gov,knoepfel@fnal.gov,Attila.Krasznahorkay@cern.ch)

--- a/_workinggroups/generators.md
+++ b/_workinggroups/generators.md
@@ -60,7 +60,7 @@ on [HSF/documents](https://github.com/HSF/documents/tree/master/CWP/papers/HSF-C
 
 ## Convenors
 
-#### Current convenors
+#### Current conveners
 
 {% assign persons = "Josh McFayden, Andrea Valassi, Efe Yazgan" | split: ", " %}
 {% include list_of_selected_profiles.html %}
@@ -69,10 +69,10 @@ on [HSF/documents](https://github.com/HSF/documents/tree/master/CWP/papers/HSF-C
 - Efe Yazgan (2020)
 - Josh McFayden (2018-2020)
 
-All convenors can be reached via <hsf-generator-wg-convenors@googlegroups.com>.
+All conveners can be reached via <hsf-generator-wg-convenors@googlegroups.com>.
 
 #### Former convenors
 
-- Stefan Hoeche (2018-2019)
-- Steve Mrenna (2018-2019)
-- Taylor Childers (2018-2019)
+- Stefan Hoeche, 2018-2019
+- Steve Mrenna, 2018-2019
+- Taylor Childers, 2018-2019

--- a/_workinggroups/pyhep.md
+++ b/_workinggroups/pyhep.md
@@ -143,5 +143,5 @@ The event was kindly sponsored by
 
 # Previous conveners
 
-- 2019 - Chris Tunnell (XENON1T)
-- 2018 - Graeme Stewart (CERN EP-SFT)
+- Chris Tunnell (XENON1T), 2019
+- Graeme Stewart (CERN EP-SFT), 2018

--- a/_workinggroups/recotrigger.md
+++ b/_workinggroups/recotrigger.md
@@ -24,7 +24,12 @@ of profiling and quality assurance toolkits.
 
 ## Get involved
 
-Current WG convenors: Caterina Doglioni, Agnieszka Dziurda, David Lange. [Contact the group convenors](mailto:caterina.doglioni@cern.ch,agnieszka.dziurda@cern.ch,david.lange@cern.ch).
+Current WG convenors: 
+- Andreas Salzburger (ATLAS)
+- David Lange (CMS)
+- Dorothea vom Bruch (LHCb)
+
+[Contact the group convenors](mailto:dorothea.vom.bruch@cern.ch,andreas.salzburger@cern.ch,david.lange@cern.ch).
 
 Everyone is welcome to participate and contribute on the forum and to the ongoing meetings. For more information, contact us or
 follow our mailing list on google groups [hsf-recotrigger](https://groups.google.com/forum/#!forum/hsf-recotrigger).
@@ -36,3 +41,7 @@ follow our mailing list on google groups [hsf-recotrigger](https://groups.google
 
 ## Details
 [Mandate and link to other HSF working groups](/organization/working-group-mandates.html).
+
+## Former Convenors
+
+- Caterina Doglioni (ATLAS), Agnieszka Dziurda (LHCb)

--- a/_workinggroups/recotrigger.md
+++ b/_workinggroups/recotrigger.md
@@ -24,12 +24,12 @@ of profiling and quality assurance toolkits.
 
 ## Get involved
 
-Current WG convenors: 
+Current WG conveners: 
 - Andreas Salzburger (ATLAS)
 - David Lange (CMS)
 - Dorothea vom Bruch (LHCb)
 
-[Contact the group convenors](mailto:dorothea.vom.bruch@cern.ch,andreas.salzburger@cern.ch,david.lange@cern.ch).
+[Contact the group conveners](mailto:dorothea.vom.bruch@cern.ch,andreas.salzburger@cern.ch,david.lange@cern.ch).
 
 Everyone is welcome to participate and contribute on the forum and to the ongoing meetings. For more information, contact us or
 follow our mailing list on google groups [hsf-recotrigger](https://groups.google.com/forum/#!forum/hsf-recotrigger).
@@ -42,6 +42,7 @@ follow our mailing list on google groups [hsf-recotrigger](https://groups.google
 ## Details
 [Mandate and link to other HSF working groups](/organization/working-group-mandates.html).
 
-## Former Convenors
+## Former Conveners
 
-- Caterina Doglioni (ATLAS), Agnieszka Dziurda (LHCb)
+- Caterina Doglioni (ATLAS), 2019-2020
+- Agnieszka Dziurda (LHCb), 2019-2020

--- a/_workinggroups/toolsandpackaging.md
+++ b/_workinggroups/toolsandpackaging.md
@@ -72,8 +72,9 @@ All the coordinators can be reached [by email](mailto:serhanmete@gmail.com,pater
 
 ### Former Conveners
 
-- Bendikt Hegner (CMS, EP-SFT)
-- Elizabeth Sexton-Kennedy (CMS)
-- Graeme A Stewart (ATLAS)
-- Ben Morgan (ATLAS and superNEMO)
-- Martin Ritter (Belle II)
+- Benedikt Hegner (CMS, EP-SFT), 2016-2017
+- Elizabeth Sexton-Kennedy (CMS), 2016-2017
+- Graeme A Stewart (ATLAS), 2017-2019
+- Ben Morgan (ATLAS, superNEMO), 2017-2020
+- Martin Ritter (Belle II), 2018-2020
+- Giulio Eulisse (ALICE), 2018

--- a/_workinggroups/toolsandpackaging.md
+++ b/_workinggroups/toolsandpackaging.md
@@ -56,15 +56,24 @@ rapidly evaluate each tool for features, ease of use and flexibility.
 Documentation for these *test drive* setups is in the group's
 [GitHib](https://github.com/HSF/packaging) repository.
 
----
+### Conveners
 
-The group is currently coordinated by Ben Morgan (Warwick, ATLAS and superNEMO), Alaettin Serhan Mete (Argonne National Laboratory, ATLAS), and Martin Ritter (LMU Munich, Belle II).
+The group is currently coordinated by:
+
+- Alaettin Serhan Mete (ATLAS)
+- Marc Paterno (DUNE)
+- Mircho Rozodov (CMS)
+
+All the coordinators can be reached [by email](mailto:serhanmete@gmail.com,paterno@fnal.gov,mircho.nikolaev.rodozov@cern.ch).
+### Activities
 
 *  The Indico pages for the working group meetings can be found at <https://indico.cern.ch/category/7975/>
-*  All coordinators can be reached at <hsf-software-tools-wg-conveners@googlegroups.com>
 *  For all technical discussions please use <hsf-tech-forum@googlegroups.com> (Tools) and <hsf-packaging-wg@googlegroups.com> (Packaging)
 
-Former Convenors:
-- Bendikt Hegner (CERN)
-- Elizabeth Sexton-Kennedy (FNAL)
-- Graeme A Stewart (CERN)
+### Former Conveners
+
+- Bendikt Hegner (CMS, EP-SFT)
+- Elizabeth Sexton-Kennedy (CMS)
+- Graeme A Stewart (ATLAS)
+- Ben Morgan (ATLAS and superNEMO)
+- Martin Ritter (Belle II)

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -34,7 +34,7 @@ The group aims to develop a training program that can be pursued by researchers 
   * The Community
     * [The HSF training community](/training/community.html)
     * [Participating & Contributing](/workinggroups/training.html#how-to-participate-and-contribute)
-    * [Convenors](/workinggroups/training.html#convenors)
+    * [Convenors](/workinggroups/training.html#conveners)
 * **Meta**:
   * [How to add your profile to the HSF training community pages](/howto-profile.html)
 
@@ -88,6 +88,7 @@ The conveners can be reached [by email](mailto:michel.hernandez.mx@gmail.com,me3
 {% include list_of_selected_profiles.html %}
 ### Former Conveners:
 
-- Dario Menasce (INFN Milano)
-- Kilian Lieret (LMU, Belle II)
-- Sam Meehan (CERN, ATLAS and FASER)
+- Dario Menasce (INFN Milano), 2016-2019
+- Kilian Lieret (LMU, Belle II), 2020
+- Sam Meehan (CERN, ATLAS and FASER), 2020
+

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -76,14 +76,18 @@ The HSF training group relies on a growing list of proactive and dedicated educa
 
 {% include list_of_upcoming_schools.md %}
 
-## Convenors
+## Conveners
 
-Kilian Lieret (LMU), Sudhir Malik (Puerto Rico), Sam Meehan (CERN)
+- Meirin Oan Evans (ATLAS)
+- Michel Hernandez Villanueva (Belle II)
+- Sudhir Malik (CMS)
 
-{% assign persons = "Kilian Lieret, Sudhir Malik, Sam Meehan" | split: ", " %}
+The conveners can be reached [by email](mailto:michel.hernandez.mx@gmail.com,me338@sussex.ac.uk,malik@fnal.gov).
+
+{% assign persons = "Meirin Oan Evans, Sudhir Malik, Michel Hernandez Villanueva" | split: ", " %}
 {% include list_of_selected_profiles.html %}
+### Former Conveners:
 
----
-
-Former Convenors:
 - Dario Menasce (INFN Milano)
+- Kilian Lieret (LMU, Belle II)
+- Sam Meehan (CERN, ATLAS and FASER)


### PR DESCRIPTION
Try to make the links to email the conveners roughly
standard, with one "mailto:" to all (though some groups
maintain separate convener email addresses).