### PR TITLE
Add documents page

### DIFF
--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -35,16 +35,19 @@
               <a class="dropdown-toggle" data-toggle="dropdown" href="/index.html" id="communication_menu">Communication<span class="caret"></span></a>
                 <ul class="dropdown-menu" aria-labelledby="communication_menu">
                   <li><a href="/future-events.html">Community Calendar</a></li>
+                  <li><a href="https://indico.cern.ch/category/5816/" target="_hsf_indico">Meetings: Indico</a></li>
                   <li><a href="/Schools/events.html">Training Schools</a></li>
-                  <li><a href="/events.html">Events &amp; Workshops</a></li>
-                  <li><a href="https://indico.cern.ch/category/5816/" target="_hsf_indico">HSF Indico</a></li>
-                  <li><a href="https://www.youtube.com/channel/UCv4hukXGkCYvBClQMKzypnQ" target="_hsf_youtube">HSF on YouTube</a></li>
                   <li class="divider"></li>
                   <li><a href="/forums.html">Mailing Lists and Forums</a></li>
-                  <li><a href="/technical_notes.html">Technical Notes</a></li>
                   <li><a href="/organization/minutes.html">Meeting Notes</a></li>
-                  <li><a href="/newsletter.html">Newsletters</a></li>
+                  <li><a href="/technical_notes.html">Technical Notes</a></li>
+                  <li><a href="/organization/documents.html">Documents</a></li>
                   <li class="divider"></li>
+                  <li><a href="/newsletter.html">Newsletters</a></li>
+                  <li><a href="/events.html">Events &amp; Workshops</a></li>
+                  <li><a href="https://www.youtube.com/c/HEPSoftwareFoundation" target="_hsf_youtube">HSF on YouTube</a></li>
+                  <li class="divider"></li>
+                  
                   <li><a href="/inventory/inventory.html">HSF Project Inventory</a></li>
                 </ul>
             </li>

--- a/organization/documents.md
+++ b/organization/documents.md
@@ -1,0 +1,17 @@
+---
+title: "HSF Documents"
+layout: plain
+---
+
+The HSF has written a number of documents and white papers, which are listed here.
+
+In addition to these documents we have [HSF Technical Notes](/technical_notes.html) and
+a full list of all of the papers connected to the [Community White Paper](/organization/cwp.html).
+
+{:.table .table-hover .table-condensed .table-striped}
+| Title           | Purpose     | Download    | Source Link |
+| ------------- | ------------- | ------------ | ----------- |
+| HL-LHC Computing Review: Common Tools and Community Software | Submitted to the May 2020 LHCC HL-LHC review and (with minor amendments) to the US Snowmass Process | <https://zenodo.org/record/4009114> | [LaTeX](https://github.com/HSF/documents/tree/master/LHCC/2020/2020-01) |
+| Monte Carlo generators challenges and strategy towards HL-LHC | Submitted to the May 2020 LHCC HL-LHC review and to the US Snowmass Process | <https://arxiv.org/abs/2004.13687> | |
+| The Importance of Software and Computing to Particle Physics | Submitted to the European Strategy Update | <https://zenodo.org/record/2413005> | [LaTeX](https://github.com/HSF/documents/tree/master/HSF-DOC/2018-01) |
+| A Roadmap for HEP Software and Computing R&D for the 2020s | [Community White Paper](/organization/cwp.html) document, also published in CSBS | <https://doi.org/10.1007/s41781-018-0018-8>, <https://arxiv.org/abs/1712.06982> | [LaTeX](https://github.com/HSF/documents/tree/master/CWP/papers/HSF-CWP-2017-01_roadmap/latex) |

--- a/organization/youtube.md
+++ b/organization/youtube.md
@@ -6,7 +6,7 @@ layout: plain
 ## Purpose
 
 The [HSF YouTube
-channel](https://www.youtube.com/channel/UCv4hukXGkCYvBClQMKzypnQ) is used to
+channel](https://www.youtube.com/c/HEPSoftwareFoundation) is used to
 host video content that should last beyond the lifetime of a single event and
 for which it is useful for people to be able to view the material 'offline'.
 


### PR DESCRIPTION
Add a missing page - all of the documents that we have written as the HSF (as noticed by @peremato).

Reorganise the "Communication" drop down a bit to emphsise the more active/useful links.
