### PR TITLE
Updating training events in January 2021

### DIFF
--- a/Schools/events.md
+++ b/Schools/events.md
@@ -10,9 +10,3 @@ title: HEP Software Training Events
 ## Past Events
 
 {% include list_of_past_schools.md %}
-
-## HSF supported/organized training events
-
-The following events were directly organized by HSF or supported by HSF.
-
-{% include list_of_hsf_schools.md %}

--- a/_data/training-schools.yml
+++ b/_data/training-schools.yml
@@ -310,3 +310,4 @@
   source: https://indico.cern.ch/event/997485/
   tags: HSF
   title: HSF Training Hackathon Follow-up
+  

--- a/_data/training-schools.yml
+++ b/_data/training-schools.yml
@@ -287,7 +287,7 @@
   deadline: ''
   end_date: 2020-11-09
   source: https://indico.cern.ch/event/958112/
-  tags: hsf
+  tags: HSF
   title: ML + GPU Training
 - author: Kilian Lieret
   date: 2020-12-16
@@ -296,3 +296,17 @@
   source: https://indico.cern.ch/event/975487/
   tags: HSF
   title: HSF Training Hackathon
+- author: Michel Villanueva
+  date: 2021-01-18
+  deadline: ''
+  end_date: 2021-01-22
+  source: https://indico.cern.ch/event/979067/
+  tags: HSF
+  title: 2nd HEP C++ Course and Hands-on Training
+- author: Michel Villanueva
+  date: 2021-01-22
+  deadline: ''
+  end_date: 2021-01-22
+  source: https://indico.cern.ch/event/997485/
+  tags: HSF
+  title: HSF Training Hackathon Follow-up


### PR DESCRIPTION
Updating the training events held in January 2021

Following the comment by Sudhir, the list at the bottom https://hepsoftwarefoundation.org/Schools/events.html is a subset if list at the top, then we can get rid of the bottom one as we already tag "HSF" in the top list.