### PR TITLE
Removed Madgraph5 mentors after withdrawal. Fixed backed-up Madgraph5 project and proposal files.

### DIFF
--- a/_gsocprojects/2021/withdrawn/project_MadGraph5.md
+++ b/_gsocprojects/2021/withdrawn/project_MadGraph5.md
@@ -1,3 +1,10 @@
-Unstaged changes after reset:
-D	_gsocprojects/2021/project_MadGraph5.md
-M	_gsocprojects/2021/redrawn/project_MadGraph5.md
+---
+project: MadGraph5
+title: MadGraph5_aMC@NLO
+layout: default
+logo: MadGraph5-logo.png
+description: |
+  [MadGraph5_aMC@NLO](https://launchpad.net/mg5amcnlo) is a framework that aims to simulate high-energy collisions for various accelerators and in particular for LHC physics. It focuses mainly on physics beyond the “Standard Model” allowing physicists to search for various scenarios in their experiments. MadGraph5 is extensively used by both theorists and experimentalists making the code one of the most cited papers every year. MadGraph5 is a meta-code written in python that generates specialised code in low-level languages (Fortran and C) to produce very fast code.
+---
+
+{% include gsoc_project.ext %}

--- a/_gsocproposals/2021/withdrawn/proposal_Madgraph5-Accelerator.md
+++ b/_gsocproposals/2021/withdrawn/proposal_Madgraph5-Accelerator.md
@@ -1,5 +1,42 @@
-Unstaged changes after reset:
-D	_gsocprojects/2021/project_MadGraph5.md
-M	_gsocprojects/2021/redrawn/project_MadGraph5.md
-D	_gsocproposals/2021/proposal_Madgraph5-Accelerator.md
-M	_gsocproposals/2021/redrawn/proposal_Madgraph5-Accelerator.md
+---
+project: MadGraph5
+title: MadGraph5 - offload event execution to accelerator devices
+layout: gsoc_proposal
+year: 2021
+organization:
+  - CERN
+  - UCLouvain
+---
+
+## Description
+High energy physics experiments such as the Large Hadron Collider (LHC) experiments at CERN rely heavily on so called “Monte Carlo (MC) Simulations” to achieve their physics research goals. MC simulations mimic in a computer program the initial collision of particles in a high energy physics collider and their subsequent response inside a physics detector.
+
+LHC experiments use a distributed computing environment of up to 500.000 computing cores and several exa-bytes of disk and tape storage for its data processing and the vast majority of the available CPU power (70 - 80 %) is used for MC simulations. Recently the provisioning of compute accelerators, such as General Purpose Graphics Processing Units (GPUs), has become popular in this computing infrastructure in addition to classical x86 Intel CPUs.
+
+Looking at the workflow of a simulation program, the very first step of it is the so called “event generation” where the initial collision of the particles in the collider is simulated. These event generators are historically written for classical x86 intel compatible architectures. With the shift of the distributed computing environment towards GPUs it is essential to make MC Generators also fit for use on those architectures.
+
+## Task ideas
+The student will work with one of the most utilised MC Generators, called Madgraph5 and develop on top of a first Cuda/C++ port of the package.
+
+NVidia provides a feature called Cuda Graphs for their programming IDE, which can can provide further speedup of the workflow. We want to enable Cuda Graphs for the most compute intensive part of the workflow called "matrix element calculation". The task includes
+
+ * Learning about Cuda Graphs
+ * Applying Cuda Graphs to the matrix element calculation module of the package
+ * Measuring the performance changes of the new implementation
+ * Documenting the changes and providing help with the porting of the changes upstream into the master project
+
+## Expected results
+The deliverable of the project is the implementation of Cuda Graphs in the Madgraph5 project, together with a performance study of the workflow with the new feature enabled.
+
+## Requirements
+We're seeking a candidate who is skilled in Cuda/C++ programming. A basic understanding of NVidia profiling tools (e.g. NSight System, NSight Compute), GNU Makefiles, git and Python are a surplus.
+
+## Mentors
+  * [Olivier Mattelaer](mailto:olivier.mattelaer@uclouvain.be) UnivLouvain
+  * **[Stefan Roiser](mailto:stefan.roiser@cern.ch)** CERN
+  * [Andrea Valassi](mailto:andrea.valassi@cern.ch) CERN
+
+## Links
+  * [MadGraph5 project](https://launchpad.net/mg5amcnlo)
+  * [Madgraph5 GPU Code](https://madgraph5.github.io/)
+  * [NVidia Cuda Graphs](https://developer.nvidia.com/blog/cuda-graphs/)

--- a/gsoc/2021/mentors.md
+++ b/gsoc/2021/mentors.md
@@ -45,7 +45,6 @@ layout: plain
 * Javier Lopez-Gomez [j.lopez@cern.ch](mailto:j.lopez@cern.ch) CERN
 * Giuseppe Lo Presti [giuseppe.lopresti@cern.ch](mailto:giuseppe.lopresti@cern.ch) CERN
 * Thomas Madlener [thomas.madlener@desy.de](mailto:thomas.madlener@desy.de) DESY
-* Olivier Mattelaer [olivier.mattelaer@uclouvain.be](mailto:olivier.mattelaer@uclouvain.be) UCLouvain
 * Lorenzo Moneta [Lorenzo.Moneta@cern.ch](mailto:Lorenzo.Moneta@cern.ch) CERN
 * William Moses [wmoses@mit.edu](mailto:wmoses@mit.edu) MIT
 * Edward Moyse [edward.moyse@cern.ch](mailto:edward.moyse@cern.ch) University of Massachusetts, Amherst
@@ -56,15 +55,13 @@ layout: plain
 * Krishnan Raghavan [krishnan.raghavan@cern.ch](mailto:krishnan.raghavan@cern.ch) CERN
 * Baptiste Ravina [baptiste.ravina@cern.ch](mailto:baptiste.ravina@cern.ch) UofGlasgow
 * Wahid Redjeb [wahid.redjeb@cern.ch](mailto:wahid.redjeb@cern.ch) Universita' degli Studi di Milano Bicocca
-* Jonas Rembser[Jonas.Rembser@cern.ch](mailto: Jonas.Rembser@cern.ch) CERN
+* Jonas Rembser[Jonas.Rembser@cern.ch](mailto:Jonas.Rembser@cern.ch) CERN
 * Alex Richards [a.richards@imperial.ac.uk](mailto:a.richards@imperial.ac.uk) Imperial College London
-* Stefan Roiser [stefan.roiser@cern.ch](mailto:stefan.roiser@cern.ch) CERN
 * Oksana Shadura [oksana.shadura@cern.ch](mailto:oksana.shadura@cern.ch) University of Nebraska-Lincoln
 * Mark Smith [mark.smith1@imperial.ac.uk](mailto:mark.smith1@imperial.ac.uk) Imperial College London
 * Graeme A Stewart [graeme.andrew.stewart@cern.ch](mailto:graeme.andrew.stewart@cern.ch) CERN
 * Alex Unger [aunger@owncloud.com](mailto:aunger@owncloud.com) ownCloud
 * Michael Usher [michael.usher@aarnet.edu.au](mailto:michael.usher@aarnet.edu.au) AARNet
-* Andrea Valassi [andrea.valassi@cern.ch](mailto:andrea.valassi@cern.ch) CERN
 * Vassil Vassilev [vvasilev@cern.ch](mailto:vvasilev@cern.ch) Princeton University
 * Pim Verschuuren [pim.verschuuren@rhul.ac.uk](mailto:pim.verschuuren@rhul.ac.uk) Royal Holloway University of London
 * Valentin Volkl [valentin.volkl@cern.ch](mailto:valentin.volkl@cern.ch) CERN


### PR DESCRIPTION
Fixes for mentors general file. Restored project and proposal files in 'withdrawn' folders.