### PR TITLE
Also generate curriculum table

### DIFF
--- a/_training/curriculum.md
+++ b/_training/curriculum.md
@@ -41,6 +41,7 @@ The curriculum is comprised of a set of standardized *modules*, so that students
 
 ## Further reads
 
+* Show all modules in a table (mostly for administrative purposes): [click here](/training/curriculum_table.html)
 * I want to **contribute** or **teach**:
 Contributions of any kind are very welcome! There are various ways you can get involved:
 

--- a/_training/curriculum_table.md
+++ b/_training/curriculum_table.md
@@ -1,0 +1,58 @@
+---
+title: "HSF Training Modules"
+layout: plain
+---
+
+<table>
+<tr>
+    <th>
+        ID
+    </th>
+    <th>
+        Name
+    </th>
+    <th>
+        Description
+    </th>
+    <th>
+        Status
+    </th>
+    <th>
+    </th>
+    <th>
+    </th>
+    <th>
+    </th>
+</tr>
+{% for module in site.data.training-modules %}
+<tr>
+<td>
+    {{ module.id }}
+</td>
+<td>
+    {{ module.name }}
+</td>
+<td>
+    {{ module.description }}
+</td>
+<td>
+    {{ module.status }}
+</td>
+<td>
+    {% unless module.webpage == "" %}
+    <a href="{{ module.webpage }}">Webpage</a>
+    {% endunless %}
+</td>
+<td>
+    {% unless module.videos == "" %}
+    <a href="{{ module.videos }}">Videos</a>
+    {% endunless %}
+</td>
+<td>
+    {% unless module.repository == "" %}
+    <a href="{{ module.repository }}">Repo</a>
+    {% endunless %}
+</td>
+</tr>
+{% endfor %}
+</table>

--- a/_training/curriculum_table.md
+++ b/_training/curriculum_table.md
@@ -3,6 +3,44 @@ title: "HSF Training Modules"
 layout: plain
 ---
 
+<style type="text/css">
+  table {
+    padding: 0;
+    width: 100%;
+  }
+  table tr {
+    border: 1px solid #cccccc;
+    background-color: white;
+    margin: 0;
+    padding: 0;
+  }
+  table tr:nth-child(2n) {
+    background-color: #f8f8f8;
+  }
+  table tr th {
+    font-weight: bold;
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 6px 13px;
+  }
+  table tr td {
+    border: 1px solid #cccccc;
+    text-align: left;
+    margin: 0;
+    padding: 6px 13px;
+  }
+  table tr th :first-child, table tr td :first-child {
+    margin-top: 0;
+  }
+  table tr th :last-child, table tr td :last-child {
+    margin-bottom: 0;
+  }
+</style>
+
+This table of the HSF training modules is mostly meant for administrative purposes.
+If you're a student and want to discover our training content, go [here](/training/curriculum.html).
+
 <table>
 <tr>
     <th>
@@ -17,17 +55,14 @@ layout: plain
     <th>
         Status
     </th>
-    <th>
-    </th>
-    <th>
-    </th>
-    <th>
+    <th>Links
     </th>
 </tr>
-{% for module in site.data.training-modules %}
+{% assign modules = site.data.training-modules | sort:"id" %}
+{% for module in modules %}
 <tr>
 <td>
-    {{ module.id }}
+    <code>{{ module.id }}</code>
 </td>
 <td>
     {{ module.name }}
@@ -40,17 +75,14 @@ layout: plain
 </td>
 <td>
     {% unless module.webpage == "" %}
-    <a href="{{ module.webpage }}">Webpage</a>
+    <a href="{{ module.webpage }}"><span class="glyphicon glyphicon-book"></span></a>
     {% endunless %}
-</td>
-<td>
+
     {% unless module.videos == "" %}
-    <a href="{{ module.videos }}">Videos</a>
+    <a href="{{ module.videos }}"><span class="glyphicon glyphicon-film"></span></a>
     {% endunless %}
-</td>
-<td>
     {% unless module.repository == "" %}
-    <a href="{{ module.repository }}">Repo</a>
+    <a href="{{ module.repository }}"><span class="glyphicon glyphicon-wrench"></span></a>
     {% endunless %}
 </td>
 </tr>


### PR DESCRIPTION
In the training meeting there was some discussion about how the new presentation of the training modules is more intuitive, but also it's harder to get an overview for us. This small additional page brings back a table view for administrative purposes.

![image](https://user-images.githubusercontent.com/13602468/117025401-2c9a2380-acfb-11eb-86a4-1f2a0d51773e.png)
