### PR TITLE
Added GSoC 2021 blogs feature and an article on how to use it.

### DIFF
--- a/_activities/gsoc.md
+++ b/_activities/gsoc.md
@@ -29,9 +29,11 @@ Information from last year’s GSoC can be found [here](/gsoc/2020/index.html).
 
 ### GSoC 2021
 
-In 2021 HSF is participating in the program as a GSoC umbrella organization, under the name CERN-HSF. Project proposals will be added until mid February and are listed [below](#projects-in-2021). There are important changes in the [program rules](https://summerofcode.withgoogle.com/rules/)  and the [timeline](https://summerofcode.withgoogle.com/how-it-works/) compared to the previous year, described in the GSoC 2021 [announcement](https://groups.google.com/g/google-summer-of-code-discuss/c/GgvbLrFBcUQ). Most notably, the student project duration has been halved (175 hours instead of 350). Adapting to this new timeline, CERN-HSF is proposing this year shorter projects having well-defined deliverables.
+In 2021 HSF is participating in the program as a GSoC umbrella organization, under the name CERN-HSF. The HSF project ideas are listed [below](#projects-in-2021). There are important changes in the [program rules](https://summerofcode.withgoogle.com/rules/)  and the [timeline](https://summerofcode.withgoogle.com/how-it-works/) compared to the previous year, described in the GSoC 2021 [announcement](https://groups.google.com/g/google-summer-of-code-discuss/c/GgvbLrFBcUQ). Most notably, the student project duration has been halved (175 hours instead of 350). Adapting to this new timeline, CERN-HSF is proposing this year shorter projects having well-defined deliverables.
 
-The 2021 GSoC edition extended the student eligibility criteria. Due to the large number of candidates in 2020 and an expected increase for this year, the selection process in our organization will be split in two phases. All candidates will have to pass pre-selection evaluation tests prepared by mentors, demonstrating the skills needed for the respective projects. Only the successful candidates will be able to engage in a personalized exchange with mentors on a given project idea, and their proposals will be evaluated for the final student selection. The detailed [timeline](/activities/gsoc.html#timeline) of these phases is shown below.
+The selection process in our organization was split in two phases. All candidates had to pass pre-selection evaluation tests prepared by mentors, demonstrating the skills needed for the respective projects. The successful candidates had a detailed exchange with mentors on a given project idea, and their proposals were evaluated for the final student selection. The detailed [timeline](/activities/gsoc.html#timeline) of these phases is shown below.
+
+The blog posts made by our 2021 students are available [here](/gsoc/2021/blogs.html).
 
 ### For Students
 
@@ -42,8 +44,6 @@ New projects for HSF GSoC in 2021 will be published by **February 19**. Meanwhil
 Please avoid having the first contact with the mentors of HSF projects before **March 9** or after **March 20**! You are encouraged to take the time to read our project proposals until **March 9**, focusing on only one or two projects that attract your interest. Once you have identified those, you should e-mail the respective mentors, attaching your CV and describing the motivation for your choice. The mentors will first propose an evaluation test, waiting for your solution. Note that the test you are given is private, your solution should be personal and the response time is part of the evaluation. Mentors will let you know the test results, and if you passed they will start discussing and helping you develop a project idea. The student application period is **March 29 - April 13**, when you will have to write and review your proposal with help from your mentors.
 
 For further information, feel free to contact the HSF GSoC admins or join our open chat channel below. Note that the channel is intended for exchanging with the admins, the other candidates and some of the CERN-HSF students from previous year, and we do not maintain a mailing list for candidates. Please avoid posting extended information about yourself in the chat channel and reserve this for the direct exchange with the mentors.
-
-##### <font color="red">Note:</font> **Projects are still seeking candidates, so you can still contact mentors according to the GSoC timeline. Some project proposals are already very popular, you will get a warning in their idea page and/or from the mentors in case you decide to contact them. Please check our project proposals pages in the coming days!**
 
 [hsf-gsoc-admin@googlegroups.com](mailto:hsf-gsoc-admin@googlegroups.com)
 
@@ -96,11 +96,11 @@ For new HEP-related groups wishing to join HSF GSoC umbrella rather than being i
     <td> Apr 13 </td>
     <td> Student application deadline </td>
   </tr>
-  <tr style="color: red;">
+  <tr>
     <td> Apr 14 - Apr 20 </td>
     <td><p><font color="blue"> Phase 2 selection </font></p> Mentors evaluate and rank student proposals. </td>
   </tr>
-  <tr style="color: red;">
+  <tr>
     <td> Apr 20 </td>
     <td> Rankings due for mentors, sent to HSF Org Admins </td>
   </tr>
@@ -120,7 +120,7 @@ For new HEP-related groups wishing to join HSF GSoC umbrella rather than being i
     <td> May 13 </td>
     <td> Student Project selections due from Org Admins </td>
   </tr>
-  <tr>
+  <tr style="color: red;">
     <td> May 17 </td>
     <td> Accepted student projects announced  </td>
   </tr>

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,9 @@ collections:
   gsocproposals:
     output: true
     permalink: /gsoc/:path.html
+  gsocblogs:
+    output: true
+    permalink: /gsoc/blogs/:path.html
   gsdocs-orgs:
     output: true
     permalink: /gsdocs/organizations/:path.html

--- a/_gsocblogs/2021/blog_HSF_TheAdmins.md
+++ b/_gsocblogs/2021/blog_HSF_TheAdmins.md
@@ -1,0 +1,47 @@
+---
+project: HSF
+title: Writing a blog about your experience with HSF in GSoC
+author: Andrei Gheata
+[//]: # (photo: blog_authors/FirstLast.jpg)
+date: 16.05.2021
+year: 2020
+layout: blog_post
+logo: hsf_logo_angled.png
+intro: |
+  If you would like to share your experience with GSoC, you can write a blog that we will review and maybe host on our HSF GSoC pages. Your experience is valuable for future GSoC candidates, but also for HSF mentors and administrators who are striving to improve the program every year. This article gives some guidelines for publishing your blog using the [HSF GitHub repository](https://github.com/HSF/hsf.github.io).
+---
+
+If you would like to share your experience with GSoC, you can write a blog that we will review and maybe host on our HSF GSoC pages. Your experience is valuable for future GSoC candidates, but also for HSF mentors and administrators who are striving to improve the program every year. This article gives some guidelines for publishing your blog using the [HSF GitHub repository](https://github.com/HSF/hsf.github.io).
+
+### Size and content
+
+While there is no formal limit, we recommend writing short articles, mainly for readability reasons. You should be focusing on your experience, rather than diving into the technical details of your project, but you could give (persistent) links to your work if you wanted to. Remember that you will anyway need to write a final technical report on the results of your project, the blog is something different. 
+
+A common approach is to write useful information for future students, giving hints or shortcuts that you may have struggled to discover, describing how you tackled certain problems or difficulties, briefly, trying to help newcomers by sharing your own experience. It may happen that your project was not as successful as you have wished for, but this does not mean you cannot write a fantastic article! You just need to find the silver lining in your experience because ultimately what matters is what you've learned from the process and if it's worth sharing it. 
+
+If you never wrote a blog, this is your opportunity to begin - there are plenty of good articles on the net for you to pick advice from, such as [this](https://smartblogger.com/how-to-write-a-blog-post/) one. Your article will be reviewed before being published on the HSF site, inappropriate content is not acceptable. You can write the article just after the final evaluation week, not to interfere with your GSoC work, but we will review it even earlier if you make a PR.
+
+### Making a pull request for your blog
+
+ * Fork git [repository](https://github.com/HEP-SF/hep-sf.github.io)
+ * Add __gsocblogs/YEAR/blog_YOURPROJECT_FirstnameLastname.md_
+ * Add a front matter, using the following labels:
+
+**project:** HSF _<span style="color:grey"> [use your project idea name, matching the same label in _gsocprojects/YEAR/project_yourproject.md]</span>_<br/>
+**title:** Firstname Lastname<br/>
+**photo:** blog_authors/FirstLast.jpg _<span style="color:grey"> [Optionally upload a squared format photo, rendered as 100x100, othrwise don't use the label]</span>_<br/>
+**date:** 16.05.2021 _<span style="color:grey"> [Use the date when you wrote the article]</span>_<br/>
+**year:** 2021 _<span style="color:grey"> [Make sure the year is correct]</span>_<br/>
+**layout:** blog_post<br/>
+**logo:** hsf_logo_angled.png _<span style="color:grey"> [Use the same file name as in _gsocprojects/YEAR/project_yourproject.md]</span>_<br/>
+**intro:** |<br/>
+Short introduction that will appear alongside other blogs. It can match the beginning of the detailed article.<br/>
+`---`<br/>
+Start your detailed article using markdown from here...
+
+ * Make a pull request (add as reviewers the admins: HSF/gsoc-admins)
+
+
+
+
+

--- a/gsoc/2021/blogs.md
+++ b/gsoc/2021/blogs.md
@@ -1,0 +1,32 @@
+---
+title: HSF student blogs for GSoC 2021
+layout: plain
+year: 2020
+---
+
+{% assign sorted_blogs = site.gsocblogs | sort: 'title' %}
+{% for blog in sorted_blogs %}
+{%- if blog.year == page.year %}
+{% assign blog_intro = blog.intro | strip_newlines | markdownify %}
+<div class="blog-header" style="text-align: left">
+  <div class="row">
+    <div class="col-md-2">
+      <img src="/images/{{ blog.logo }}" alt="{{ blog.project }}" width="100px">
+    </div>
+    <div class="col-md-7" style="text-align: left;">
+      <h1>{{ blog.title }}</h1>
+    </div> 
+    <div class="col-md-2" style="vertical-align: bottom;">
+      {% if blog.photo %}
+      <img src="/images/{{ blog.photo }}" alt="{{ blog.author }}" width="100px">
+      {% endif %}
+      <p style="font-weight: bold; text-align: center;"> by: {{ blog.author }}</p> 
+    </div>
+  </div>
+</div>
+{{blog_intro}}
+
+[ Read more ... ]( {{ blog.url }} )
+<hr>
+{%- endif -%}
+{% endfor %}


### PR DESCRIPTION
This adds the possibility to add GSoC student blogs in a similar way as for GSDocs. It adds also a guideline for blog writers. Advanced the GSoC internal timeline to the last item and adjusted the text to past tense for past activities. The added link to the guideline for blogs may not work until the PR is actually merged.