### PR TITLE
Use gravatar for placeholder images if neither gravatar/github given

### DIFF
--- a/_includes/profile_avatar.html
+++ b/_includes/profile_avatar.html
@@ -1,7 +1,7 @@
 <!-- Make sure to include educator_header to use this -->
 
-{% if person.gravatar %}
-<img data-src="https://www.gravatar.com/avatar/{{ person.gravatar }}?d=mp" class="img-circle lazyload" alt="Gravatar profile photo of {{person.title}}">
-{% else %}
+{% if person.github and person.gravatar == nil %}
 <img data-src="https://avatars.githubusercontent.com/{{ person.github }}" class="img-circle lazyload" alt="GitHub profile photo of {{person.title}}">
+{% else %}
+<img data-src="https://www.gravatar.com/avatar/{{ person.gravatar }}?d=mp" class="img-circle lazyload" alt="Gravatar profile photo of {{person.title}}">
 {% endif %}


### PR DESCRIPTION
If a person specifies neigher gravatar nor github we will still request an image from gravatar because it returns an empty picture

![image](https://user-images.githubusercontent.com/13602468/124153985-540c3300-da95-11eb-96bc-be2afce35aa5.png)
