### PR TITLE
Add emery; reformat/update profiles

### DIFF
--- a/_profiles/emery_nibigira.md
+++ b/_profiles/emery_nibigira.md
@@ -1,0 +1,22 @@
+---
+title: Emery NIBIGIRA
+training_years:
+- 20
+- 21
+- 202
+training_roles:
+- facilitator
+- instructor
+gravatar: null
+github: enibigir
+gitlab: enibigir
+bitbucket: null
+homepage: null
+twitter: EmeryNibigira
+orcid: 0000-0001-5821-291X
+linkedin: null
+email: emery.nibigira@cern.ch
+layout: educator
+---
+
+I am currently working as a member of the CMS collaboration. I am involved with tracking detector commissioning, Beam test, Code development, Data Acquisition. As well as Simulation and Data Analysis in the context of searches for New Physics.

--- a/_profiles/johan_sebastian_bonilla.md
+++ b/_profiles/johan_sebastian_bonilla.md
@@ -5,6 +5,7 @@ training_years:
 - 21
 - 202
 training_roles:
+- instructor
 - mentor
 gravatar: null
 github: AFJohan92

--- a/_profiles/stephen_swatman.md
+++ b/_profiles/stephen_swatman.md
@@ -1,9 +1,6 @@
 ---
-# Required:
 title: Stephen Nicholas Swatman
 country: FR
-
-# Optional (please add github or gravatar for your picture)
 github: stephenswat
 gravatar: null
 homepage: https://v25.nl/
@@ -13,12 +10,12 @@ bitbucket: null
 orcid: 0000-0002-3747-3229
 linkedin: stephen-nicholas-swatman-913a088a
 email: stephen@v25.nl
-
-# Training WG
-training_roles: [instructor, mentor]
-training_years: [2020, 2021]
-
-# Don't modify the following setting
+training_roles:
+- instructor
+- mentor
+training_years:
+- 2020
+- 2021
 layout: educator
 ---
 

--- a/_profiles/sudhir_malik.md
+++ b/_profiles/sudhir_malik.md
@@ -1,17 +1,20 @@
 ---
 title: Sudhir Malik
-country: USA
-training_roles: []
 training_years:
 - 2019
 - 2020
-github: fatala22
+- 2021
+training_roles:
+- facilitator
 gravatar: null
+github: fatala22
+gitlab: null
+bitbucket: null
 homepage: http://charma.uprm.edu/~malik/
 twitter: SudhirM39407009
-gitlab: null
 orcid: 0000-0002-6356-2655
 linkedin: sudhir-malik-19932534
+email: null
 layout: educator
+country: USA
 ---
-I am a Professor of Physics at University of Puerto Rico Mayaguez. My area of research is Particle Physics and I work on CMS Experiment at the Large Hadron Collider. My interests are Silicon Detectors, Beyond Standard Model Physics, Software and Physics Analysis Training and Outreach.


### PR DESCRIPTION
Adding Emery; reformatting manually added profiles; bug in https://github.com/HSF/website-helpers caused some training roles not to be updated, this is fixed [now](https://github.com/HSF/website-helpers/commit/f7f46e694024146071f17154fc8040a80c3594d4) 