### PR TITLE
Rebrand curriculum to "HSF Software Training Center"

### DIFF
--- a/_training/curriculum.md
+++ b/_training/curriculum.md
@@ -1,5 +1,5 @@
 ---
-title: "Towards a HEP Software Training curriculum"
+title: HSF Software Training Center
 layout: plain
 ---
 


### PR DESCRIPTION
Following up with a suggestion from Claire David from quite some time ago