### PR TITLE
Add pre-commit config to check for absolute URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/klieret/jekyll-relative-url-hook
+    rev: 99e0e8dd46b99eb07a646927149482b2f6718207
+    hooks:
+    -   id: jekyll_relative_url_html
+    -   id: jekyll_relative_url_markdown
+


### PR DESCRIPTION
Following up with https://github.com/HSF/hsf.github.io/pull/976, this adds a config for [pre-commit](https://results.pre-commit.ci/) to the repository.

To install/test locally:

```
pip3 install pre-commit
pre-commit install
```

and this will check for wrong absolute URLs every time you commit (I wrote the checks and it's very basic at the moment, but it should catch something at least)

@admins: Could you enable the CI for it: It's a github addon that can be added to a repo here: https://pre-commit.ci/

Once we have pre-commit running I will also add a few other hooks that will catch some common issues (e.g. I already checked codespell, which has almost 0 false positives on the whole repo)