### PR TITLE
Fix link to home

### DIFF
--- a/_includes/navbar.ext
+++ b/_includes/navbar.ext
@@ -2,7 +2,7 @@
 <div class="navbar navbar-default">
     <div class="container">
         <div class="navbar-header">
-          <a href="{{site.baseurl}}" class="navbar-brand"><span class="glyphicon glyphicon-home"></span>&nbsp;&nbsp;HSF</a>
+          <a href="{{site.baseurl}}/" class="navbar-brand"><span class="glyphicon glyphicon-home"></span>&nbsp;&nbsp;HSF</a>
           <button class="navbar-toggle" type="button" data-toggle="collapse" data-target="#navbar-main">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>


### PR DESCRIPTION
If the slash isn't present and site.baseurl isn't set this will be an
empty href (which means that the link will point to the currently active
page).

Probably this issue was introduced when I added `site.baseurl` everywhere in #976 