### PR TITLE
Add link checker replacement pattern for site.baseurl

### DIFF
--- a/.github/config/mdcheck.json
+++ b/.github/config/mdcheck.json
@@ -16,7 +16,7 @@
     {
       "pattern": "^\\s*{{\\s*site.baseurl\\s*}}\\s*/(.*)",
       "replacement": "/_site/$1"
-    },
+    }
   ],
   "timeout": "20s",
   "retryOn429": true,

--- a/.github/config/mdcheck.json
+++ b/.github/config/mdcheck.json
@@ -12,7 +12,11 @@
     {
       "pattern": "^/",
       "replacement": "{{BASEURL}}/"
-    }
+    },
+    {
+      "pattern": "^\\s*{{\\s*site.baseurl\\s*}}\\s*/(.*)",
+      "replacement": "/_site/$1"
+    },
   ],
   "timeout": "20s",
   "retryOn429": true,


### PR DESCRIPTION
Currently the link checker complains about URLs like `{{ site.baseurl }} / get_involved.html`, because it doesn't expand `{{ site.baseurl }}`. Let's see if we can fix this