### PR TITLE
pre-commit hook to check for correct syntax in JSON/YAML

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
     -   id: codespell
         args: ["-I", "codespell.txt"]
         types_or: ["markdown"]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: check-json
+    -   id: check-yaml
 
 ci:
     autoupdate_schedule: monthly


### PR DESCRIPTION
After seeing that the link checker silently ignored part of its config file due to wrong JSON syntax in #1018, this should always warn about issues with our json/yaml files.