### PR TITLE
Update conveners for 2022

### DIFF
--- a/_workinggroups/dataanalysis.md
+++ b/_workinggroups/dataanalysis.md
@@ -21,17 +21,21 @@ between physics analysis experts and technical innovators, fostering
 collaboration between these two communities to produce optimal solutions to a 
 well-defined set of problems.
 
-[Meetings](https://indico.cern.ch/category/10914)
-[Forum](https://groups.google.com/forum/#!forum/hsf-analysis-wg)
+- [Meetings](https://indico.cern.ch/category/10914) (Indico)
+- [Forum](https://groups.google.com/forum/#!forum/hsf-analysis-wg) (Mailing list)
 
-Convenors: Allison Hall (CMS), TJ Khoo (ATLAS), Nicola Skidmore (LHCb)
+## Conveners 
 
-* Contact the [convenors by email](mailto:ahall@fnal.gov,teng.jian.khoo@cern.ch,nicola.skidmore@cern.ch) <!-- markdown-link-check-disable-line -->
+- Allison Hall, CMS and FNAL
+- Stephan Hageboeck, ATLAS and CERN
+- Nicola Skidmore, LHCb and University of Manchester
 
----
+Contact the [convenors by email](mailto:ahall@fnal.gov,stephan.hageboeck@cern.ch,nicola.skidmore@cern.ch) <!-- markdown-link-check-disable-line -->
 
-Former Convenors:
+### Former Convenors
+
 - Danilo Piparo (ROOT), 2019
 - Andrea Rizzi (CMS), 2019-2020
 - Paul Laycock (Belle II), 2019-2020
 - Chris Burr (LHCb), 2020
+- TJ Khoo (ATLAS), 2020-2021

--- a/_workinggroups/detsim.md
+++ b/_workinggroups/detsim.md
@@ -19,8 +19,14 @@ technologies) are an important area of work.
 The group's meeting page is [in Indico](https://indico.cern.ch/category/10916/) and
 discussions are held on the [hsf-simulation](https://groups.google.com/forum/#%21forum/hsf-simulation) list.
 
-- Conveners: Ben Morgan (ATLAS, Geant4), Kevin Pedro (CMS), Krzysztof Genser (Mu2e, Geant4)
-- Email: [HSF Simulation WG Conveners](mailto:Ben.Morgan@warwick.ac.uk,kpedro88@gmail.com,genser@fnal.gov)
+## Conveners
+
+- Ben Morgan (ATLAS, Geant4, University of Warwick)
+- Kevin Pedro (CMS, Fermilab)
+- Krzysztof Genser (Mu2e, Geant4, Fermilab)
+
+[Email the conveners](mailto:Ben.Morgan@warwick.ac.uk,kpedro88@gmail.com,genser@fnal.gov).
+
 ### Former Conveners
 
 - Heather Gray (ATLAS), 2019

--- a/_workinggroups/frameworks.md
+++ b/_workinggroups/frameworks.md
@@ -46,8 +46,14 @@ discussions are held on the [hsf-tech-forum](https://groups.google.com/forum/#%2
 
 The group conveners are:
 
-- Chris Jones, FNAL <cdj@fnal.gov>
-- Kyle Knoepfel, FNAL <knoepfel@fnal.gov>
-- Attila Krasznahorkay, CERN <Attila.Krasznahorkay@cern.ch>
+- Benedikt Hegner, CERN and FCC
+- Kyle Knoepfel, FNAL and Neutrino Platform
+- Matti Kortelainen, FNAL and CMS
+- Vakho Tsulaia, LBNL and ATLAS
 
-[Email WG Conveners](mailto:cdj@fnal.gov,knoepfel@fnal.gov,Attila.Krasznahorkay@cern.ch)
+[Email the WG Conveners](mailto:benedikt.hegner@cern.ch,knoepfel@fnal.gov,matti.kortelainen@cern.ch,vakhtang.tsulaia@cern.ch). <!-- markdown-link-check-disable-line -->
+
+### Former Conveners
+
+- Chris Jones, FNAL 2020-2021
+- Attila Krasznahorkay, CERN 2020-2021

--- a/_workinggroups/frameworks.md
+++ b/_workinggroups/frameworks.md
@@ -46,10 +46,10 @@ discussions are held on the [hsf-tech-forum](https://groups.google.com/forum/#%2
 
 The group conveners are:
 
-- Benedikt Hegner, CERN and FCC
-- Kyle Knoepfel, FNAL and Neutrino Platform
-- Matti Kortelainen, FNAL and CMS
-- Vakho Tsulaia, LBNL and ATLAS
+- Benedikt Hegner, Key4hep and CERN
+- Kyle Knoepfel, Neutrino Platform and Fermilab
+- Matti Kortelainen, CMS and Fermilab
+- Vakho Tsulaia, ATLAS and LBNL
 
 [Email the WG Conveners](mailto:benedikt.hegner@cern.ch,knoepfel@fnal.gov,matti.kortelainen@cern.ch,vakhtang.tsulaia@cern.ch). <!-- markdown-link-check-disable-line -->
 

--- a/_workinggroups/generators.md
+++ b/_workinggroups/generators.md
@@ -62,14 +62,15 @@ on [HSF/documents](https://github.com/HSF/documents/tree/master/CWP/papers/HSF-C
 
 #### Current convenors
 
-- Andrea Valassi (2018-2021)
-- Efe Yazgan (2020-2021)
-- Josh McFayden (2018-2021)
+- Markus Deifenthaler, EIC and JLab (2022)
+- Efe Yazgan, CMS and National Taiwan University (2020-2022)
+- Josh McFayden, ATLAS and University of Sussex (2018-2022)
 
-All convenors can be reached via <hsf-generator-wg-convenors@googlegroups.com>.
+All convenors can be reached [by email](mailto:hsf-generator-wg-convenors@googlegroups.com). <!-- markdown-link-check-disable-line -->
 
 #### Former convenors
 
 - Stefan Hoeche (2018-2019)
 - Steve Mrenna (2018-2019)
 - Taylor Childers (2018-2019)
+- Andrea Valassi (2018-2021)

--- a/_workinggroups/pyhep.md
+++ b/_workinggroups/pyhep.md
@@ -192,4 +192,4 @@ The event was kindly sponsored by
 
 - Chris Tunnell (XENON1T), 2019
 - Graeme Stewart (CERN EP-SFT), 2018
-- Ben Kirkler (LZ, CMS) 2020
+- Ben Krikler (LZ, CMS) 2020

--- a/_workinggroups/pyhep.md
+++ b/_workinggroups/pyhep.md
@@ -8,8 +8,9 @@ redirect_from:
 The PyHEP working group brings together a community of developers and users of Python in Particle Physics, with the aim of improving
 the sharing of knowledge and expertise. It embraces the broad community, from HEP to the Astroparticle and Intensity Frontier communities.
 
-The group is currently coordinated by Ben Krikler (CMS, LZ), Eduardo Rodrigues (LHCb) and Jim Pivarski (CMS).
-All coordinators can be reached via <hsf-pyhep-organisation@googlegroups.com>.
+The group is currently coordinated by Eduardo Rodrigues (LHCb, University of Liverpool), Oksana Shadura (IRIS-HEP, University of Nebraska) and Jim Pivarski (CMS, Princeton).
+
+All coordinators can be reached at <hsf-pyhep-organisation@googlegroups.com>.
 
 # Getting Involved
 
@@ -191,3 +192,4 @@ The event was kindly sponsored by
 
 - Chris Tunnell (XENON1T), 2019
 - Graeme Stewart (CERN EP-SFT), 2018
+- Ben Kirkler (LZ, CMS) 2020

--- a/_workinggroups/recotrigger.md
+++ b/_workinggroups/recotrigger.md
@@ -24,25 +24,28 @@ of profiling and quality assurance toolkits.
 
 ## Get involved
 
-Current WG conveners: 
-- Andreas Salzburger (ATLAS)
-- David Lange (CMS)
-- Dorothea vom Bruch (LHCb)
+Current WG conveners:
 
-[Contact the group conveners](mailto:dorothea.vom.bruch@cern.ch,andreas.salzburger@cern.ch,david.lange@cern.ch).
+- Andreas Salzburger (ATLAS, CERN)
+- Jin Huang (EIC, BNL)
+- Dorothea vom Bruch (LHCb, CPPM)
+
+[Contact the group conveners](mailto:dorothea.vom.bruch@cern.ch,andreas.salzburger@cern.ch,jhuang@bnl.gov) by email. <!-- markdown-link-check-disable-line -->
 
 Everyone is welcome to participate and contribute on the forum and to the ongoing meetings. For more information, contact us or
 follow our mailing list on google groups [hsf-recotrigger](https://groups.google.com/forum/#!forum/hsf-recotrigger).
 
 ## Group activities
 
-* Reconstruction+Trigger group meetings: [agendas](https://indico.cern.ch/category/10917/) 
-* Reconstruction+Trigger sessions at HOW2019 JLab include discussions on real-time analysis, reconstruction on accelerators, and more: [agenda](https://indico.cern.ch/event/759388/timetable/#20190320.detailed).
+- Reconstruction+Trigger group meetings: [agendas](https://indico.cern.ch/category/10917/) 
+- Reconstruction+Trigger sessions at HOW2019 JLab include discussions on real-time analysis, reconstruction on accelerators, and more: [agenda](https://indico.cern.ch/event/759388/timetable/#20190320.detailed).
 
 ## Details
+
 [Mandate and link to other HSF working groups]({{ site.baseurl }}/organization/working-group-mandates.html).
 
 ## Former Conveners
 
 - Caterina Doglioni (ATLAS), 2019-2020
 - Agnieszka Dziurda (LHCb), 2019-2020
+- David Lange (CMS), 2019-2021

--- a/_workinggroups/toolsandpackaging.md
+++ b/_workinggroups/toolsandpackaging.md
@@ -43,9 +43,9 @@ more of a focus on deployment and end user development issues.
 
 This resulted in the writing of
 
-* A set of [use cases](https://docs.google.com/document/d/1h-r3XPIXXxmr5tThIh6gu6VcXXRhBXtUuOv14ju3oTI/edit?usp=sharing)
+- A set of [use cases](https://docs.google.com/document/d/1h-r3XPIXXxmr5tThIh6gu6VcXXRhBXtUuOv14ju3oTI/edit?usp=sharing)
 that give the high level goals for an integrated and shared suite of packaging tools.
-* A [test stack](https://docs.google.com/document/d/1LW8OsTFFA9QwsJ9fASkRoJ2E6Gk3UGnOQIcElCL8UCM/edit?usp=sharing)
+- A [test stack](https://docs.google.com/document/d/1LW8OsTFFA9QwsJ9fASkRoJ2E6Gk3UGnOQIcElCL8UCM/edit?usp=sharing)
 of core HEP software packages that can be used to demonstrate how different
 tools perform against the use cases that were identified.
 
@@ -60,15 +60,16 @@ Documentation for these *test drive* setups is in the group's
 
 The group is currently coordinated by:
 
-- Alaettin Serhan Mete (ATLAS)
-- Marc Paterno (DUNE)
-- Mircho Rozodov (CMS)
+- Alaettin Serhan Mete (ATLAS and ANL)
+- Marc Paterno (DUNE and Fermilab)
+- Valentin Volkl (FCC and CERN)
 
-All the coordinators can be reached [by email](mailto:serhanmete@gmail.com,paterno@fnal.gov,mircho.nikolaev.rodozov@cern.ch).
+All the coordinators can be reached [by email](mailto:serhanmete@gmail.com,paterno@fnal.gov,valentin.volkl@cern.ch). <!-- markdown-link-check-disable-line -->
+
 ### Activities
 
-*  The Indico pages for the working group meetings can be found at <https://indico.cern.ch/category/7975/>
-*  For all technical discussions please use <hsf-tech-forum@googlegroups.com> (Tools) and <hsf-packaging-wg@googlegroups.com> (Packaging)
+- The Indico pages for the working group meetings can be found at <https://indico.cern.ch/category/7975/>
+- For all technical discussions please use <hsf-tech-forum@googlegroups.com> (Tools) and <hsf-packaging-wg@googlegroups.com> (Packaging)
 
 ### Former Conveners
 
@@ -78,3 +79,4 @@ All the coordinators can be reached [by email](mailto:serhanmete@gmail.com,pater
 - Ben Morgan (ATLAS, superNEMO), 2017-2020
 - Martin Ritter (Belle II), 2018-2020
 - Giulio Eulisse (ALICE), 2018
+- Mircho Rozodov (CMS), 2021

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -145,24 +145,23 @@ We are always looking for volunteers from the community to help us with our trai
   </a>
 </div>
 
-
 Upcoming schools:
 
 {% include list_of_upcoming_schools.md %}
 
 ## Conveners
 
-- Meirin Oan Evans (ATLAS)
-- Michel Hernandez Villanueva (Belle II)
-- Sudhir Malik (CMS)
+- Wouter Doudeck (EIC, University of Manitoba)
+- Kilian Lieret (LMU, Belle II, *from July 2022*)
+- Michel Hernandez Villanueva (Belle II, DESY)
+- Sudhir Malik (CMS, University of Puerto Rico)
 
-The conveners can be reached [by email](mailto:michmx@phy.olemiss.edu,me338@sussex.ac.uk,malik@fnal.gov). <!-- markdown-link-check-disable-line -->
+The conveners can be [reached by email](mailto:michel.hernandez.villanueva@desy.de,wouter.deconinck@umanitoba.ca,malik@fnal.gov,kilian.lieret@posteo.de). <!-- markdown-link-check-disable-line -->
 
-{% assign persons = "Meirin Oan Evans, Sudhir Malik, Michel Hernandez Villanueva" | split: ", " %}
+{% assign persons = "Kilian Lieret, Sudhir Malik, Michel Hernandez Villanueva, Wouter Doudeck" | split: ", " %}
 {% include list_of_selected_profiles.html %}
 ### Former Conveners:
 
 - Dario Menasce (INFN Milano), 2016-2019
-- Kilian Lieret (LMU, Belle II), 2020
 - Sam Meehan (CERN, ATLAS and FASER), 2020
-
+- Meirin Oan Evans (ATLAS), 2021

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -16,7 +16,7 @@ The HSF Training Working Group aims to help the research community to provide tr
 The group aims to develop a training program that can be pursued by researchers to achieve the level of required knowledge. This ranges from basic core software skills needed by everyone to the advanced training required by specialists in software and computing.
 
 <div class="big-link-container">
-  <a href="/Schools/events.html">
+  <a href="{{site.baseurl}}/Schools/events.html">
     Join an event!<br/>
     Discover new topics together with mentors and peers!
   </a>
@@ -151,14 +151,14 @@ Upcoming schools:
 
 ## Conveners
 
-- Wouter Doudeck (EIC, University of Manitoba)
-- Kilian Lieret (LMU, Belle II, *from July 2022*)
+- Wouter Deconinck (EIC, University of Manitoba)
+- Kilian Lieret (Belle II, LMU, *from July 2022*)
 - Michel Hernandez Villanueva (Belle II, DESY)
 - Sudhir Malik (CMS, University of Puerto Rico)
 
 The conveners can be [reached by email](mailto:michel.hernandez.villanueva@desy.de,wouter.deconinck@umanitoba.ca,malik@fnal.gov,kilian.lieret@posteo.de). <!-- markdown-link-check-disable-line -->
 
-{% assign persons = "Kilian Lieret, Sudhir Malik, Michel Hernandez Villanueva, Wouter Doudeck" | split: ", " %}
+{% assign persons = "Kilian Lieret, Sudhir Malik, Michel Hernandez Villanueva, Wouter Deconinck" | split: ", " %}
 {% include list_of_selected_profiles.html %}
 ### Former Conveners:
 


### PR DESCRIPTION
Make sure conveners list all the right people for 2022.
Light consistency update for all working groups to ensure
that both experiment and affiliation are listed.