### PR TITLE
Add marcel_stimberg.md to _profiles

### DIFF
--- a/_profiles/marcel_stimberg.md
+++ b/_profiles/marcel_stimberg.md
@@ -1,0 +1,21 @@
+---
+title: Marcel Stimberg
+country: FR
+
+github: mstimberg
+gravatar: null
+homepage: null
+twitter: marcelstimberg
+gitlab: null
+bitbucket: mstimberg
+orcid: 0000-0002-2648-4790
+linkedin: null
+email: marcel.stimberg@inserm.fr
+
+# Training WG
+training_roles: ["instructor"]              # subset of [facilitator, instructor, mentor], can stay empty ([])
+training_years: [2021]              # in which years did you help out? (e.g. [2020, 2019])
+
+layout: educator
+---
+


### PR DESCRIPTION
I've been an instructor for last year's Software Carpentry workshop (https://indico.cern.ch/event/1097111/timetable/), this PR adds my profile to the community page.