### PR TITLE
Fix link checker for most cases

### DIFF
--- a/.github/config/mdcheck.json
+++ b/.github/config/mdcheck.json
@@ -7,15 +7,11 @@
   "replacementPatterns": [
     {
       "pattern": "^/(.*)",
-      "replacement": "/_site/$1"
-    },
-    {
-      "pattern": "^/",
-      "replacement": "{{BASEURL}}/"
+      "replacement": "https://hepsoftwarefoundation.org/$1"
     },
     {
       "pattern": "^\\s*{{\\s*site.baseurl\\s*}}\\s*/(.*)",
-      "replacement": "/_site/$1"
+      "replacement": "https://hepsoftwarefoundation.org/$1"
     }
   ],
   "timeout": "20s",

--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -152,7 +152,7 @@ Upcoming schools:
 ## Conveners
 
 - Wouter Deconinck (EIC, University of Manitoba)
-- Kilian Lieret (Belle II, LMU, *from July 2022*)
+- Kilian Lieret (Belle II, LMU, *from June 2022*)
 - Michel Hernandez Villanueva (Belle II, DESY)
 - Sudhir Malik (CMS, University of Puerto Rico)
 


### PR DESCRIPTION
This is only a half-hearted fix: It will fail if you create a new page
and link to it before it is published.
See https://github.com/HSF/hsf.github.io/issues/1046 for more
information.