### PR TITLE
Update GSoC layout to add required information for 2022 proposals

### DIFF
--- a/_layouts/gsoc_proposal.html
+++ b/_layouts/gsoc_proposal.html
@@ -8,6 +8,13 @@ layout: default
 
   {{ content }}
 
+<h2>Additional Information</h2>
+  <ul>
+      <li>Difficulty level (low / medium / high): {{ page.difficulty }}</li>
+      <li>Duration: {{ page.duration }} hours</li>
+      <li>Mentor availability: {{ page.mentor_avail }}</li>
+  </ul>
+
 <h2>Corresponding Project</h2>
   <ul>
       <li><a href="{{ site.baseurl }}/gsoc/projects/{{ page.year }}/project_{{ page.project }}.html">{{ page.project }}</a></li>


### PR DESCRIPTION
This commit adds the `Additional Information` section based on the page header information.  See below for an example.
```
---
title: Title of the proposal
layout: gsoc_proposal
project: TheProject
year: 2022
organization: TheOrganization
difficulty: medium
duration: 175
mentor_avail: Add here availability information
---
```