### PR TITLE
Conditionally show the `Additional Information` section in GSoC proposals

### DIFF
--- a/_layouts/gsoc_proposal.html
+++ b/_layouts/gsoc_proposal.html
@@ -8,12 +8,14 @@ layout: default
 
   {{ content }}
 
+{% if page.year >= 2022 %}
 <h2>Additional Information</h2>
   <ul>
       <li>Difficulty level (low / medium / high): {{ page.difficulty }}</li>
       <li>Duration: {{ page.duration }} hours</li>
       <li>Mentor availability: {{ page.mentor_avail }}</li>
   </ul>
+{% endif %}
 
 <h2>Corresponding Project</h2>
   <ul>


### PR DESCRIPTION
The `Additional Information` section should only shown starting from year 2022, therefore preserving the aspect of previous years' proposals.

This is a follow-up PR of #1060.