### PR TITLE
Fix a wrong space in MadAnalysis 5 project GSoC proposal

### DIFF
--- a/_gsocproposals/2022/proposal_MadAnalysis-mcweights.md
+++ b/_gsocproposals/2022/proposal_MadAnalysis-mcweights.md
@@ -1,7 +1,7 @@
 ---
 title: MadAnalysis 5 - Integration of theoretical uncertainty calculation with multiweight integration
 layout: gsoc_proposal
-project: MadAnalysis 5
+project: MadAnalysis5
 year: 2022
 difficulty: medium
 duration: 350


### PR DESCRIPTION
Rename the MadAnalysis project file to be consistent with the project name