### PR TITLE
Fix link from MA5 project to its proposal.

### DIFF
--- a/_gsocprojects/2022/project_MadAnalysis5.md
+++ b/_gsocprojects/2022/project_MadAnalysis5.md
@@ -1,5 +1,5 @@
 ---
-project: MadAnalysis 5
+project: MadAnalysis5
 layout: default
 logo: MadAnalysis5-logo.png
 description: |


### PR DESCRIPTION
The to MadAnalysis 5 project page has the link to the proposal with this fix.