### PR TITLE
GSoC ATHENA: Fixes for trailing spaces

### DIFF
--- a/_gsocorgs/2022/eic.md
+++ b/_gsocorgs/2022/eic.md
@@ -5,12 +5,12 @@ layout: default
 organization: EIC
 logo: EIC-logo.png
 description: |
-  The [Electron-Ion Collider (EIC)](https://www.bnl.gov/eic/) will be a particle accelerator
-  that collides electrons with protons and nuclei to produce snapshots of those particles’
+  The [Electron-Ion Collider (EIC)](https://www.bnl.gov/eic/) will be a particle accelerator 
+  that collides electrons with protons and nuclei to produce snapshots of those particles’ 
   internal structure—like a CT scanner for atoms. The electron beam will reveal the arrangement 
   of the quarks and gluons that make up the protons and neutrons of nuclei. The force that 
-  holds quarks together, carried by the gluons, is the strongest force in Nature. The EIC will
-  allow us to study this “strong nuclear force” and the role of gluons in the matter within and
+  holds quarks together, carried by the gluons, is the strongest force in Nature. The EIC will 
+  allow us to study this “strong nuclear force” and the role of gluons in the matter within and 
   all around us. 
 ---
 

--- a/_gsocprojects/2022/project_ATHENA.md
+++ b/_gsocprojects/2022/project_ATHENA.md
@@ -3,12 +3,12 @@ project: ATHENA
 layout: default
 logo: ATHENA-logo.png
 description: |
-  The [ATHENA collaboration](https://athena-eic.org) is developing a forward-looking
-  community-focused software environment for future experiments at the Electron-Ion
-  Collider.
+  The [ATHENA collaboration](https://athena-eic.org) is developing a forward-looking 
+  community-focused software environment for future experiments at the Electron-Ion 
+  Collider. 
 summary: |
-  Based on widely-used community components (DD4hep, Gaudi, ACTS, EDM4hep) and in
-  close collaboration with the key4HEP project, the ATHENA software environment is
+  Based on widely-used community components (DD4hep, Gaudi, ACTS, EDM4hep) and in 
+  close collaboration with the key4HEP project, the ATHENA software environment is 
   intended to be a general solution for all Electron-Ion Collider.
 ---
 

--- a/_gsocproposals/2022/proposal_ATHENA-Clustering-on-GPUs.md
+++ b/_gsocproposals/2022/proposal_ATHENA-Clustering-on-GPUs.md
@@ -40,7 +40,7 @@ using SYCL.
    benchmark data sets provided by the mentors.
  * Identify the algorithm components that are most likely to benefit from GPU
    acceleration.
- * Develop a plan for the implementation of the identified algroithm componetns
+ * Develop a plan for the implementation of the identified algroithm components
    in SYCL.
  * Convert a first algorithm component, and test the achieved performance gain
    on a single target architecture.


### PR DESCRIPTION
Turns out I needed to add some more trailing space in the description blocks as well to prevent words running together.

@agheata sorry about this bugfix.