### PR TITLE
Fix Escape image suffix

### DIFF
--- a/_gsocorgs/2022/escape.md
+++ b/_gsocorgs/2022/escape.md
@@ -3,7 +3,7 @@ title: "ESCAPE"
 author: "Enrique Garcia"
 layout: default
 organization: ESCAPE
-logo: Escape-logo.jpg
+logo: Escape-logo.png
 description: |
   [ESCAPE](https://projectescape.eu/) mission is to establish a single 
   cluster of next generation European 

--- a/_gsocproposals/2022/proposal_ESCAPE-repository-as-a-service.md
+++ b/_gsocproposals/2022/proposal_ESCAPE-repository-as-a-service.md
@@ -6,7 +6,8 @@ year: 2022
 difficulty: medium
 duration: 175
 mentor_avail: June-September
-organization: ESCAPE
+organization: 
+  - ESCAPE
 ---
 
 ## Description


### PR DESCRIPTION
@agheata, @hegner : the `https://hepsoftwarefoundation.org/gsoc/organizations/2022/escape.html` page is empty and  right now I don't see why … so the WIP …