### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem "html-proofer"
 # Suggested by Jekyll
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
-# Required on Windows, although should be harmless on other platforms
-gem 'tzinfo-data'
+# Required on Windows
+gem 'tzinfo-data'  if Gem.win_platform?
 
-# Needed for Ruby > 3.1? Changed dependencies
+# Needed for Ruby > 3.1? due to changed dependencies
 gem 'webrick'

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,8 @@ gem "html-proofer"
 # Suggested by Jekyll
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
-# Required on Windows for recent versions (>= 3.6) of Jekyll
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+# Required on Windows, although should be harmless on other platforms
+gem 'tzinfo-data'
+
+# Needed for Ruby > 3.1? Changed dependencies
+gem 'webrick'


### PR DESCRIPTION
A 'fresh' checkout of the website on a new Windows machine, which also had Ruby 3.1.1,
required that the removal of the platform specifier for tzinfo-data and an explicit addition of webrick.

These changes were backported to an older setup (Ruby 2.7.2 on OS X)
and they don't cause any problems there.