### PR TITLE
Announce PyHEP 2022 on homepage

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -68,8 +68,9 @@ in High Energy Physics software and computing internationally.
     </p>
     <img src="/images/pyhep/PyHEP_logo_template_white.png"
     alt="PyHEP-logo" style="display: block; width:55%; margin-left: auto; margin-right: auto;">
-    <p> After the huge success of PyHEP in 2021 the workshop is back, again as a virtual event. The call for abstracts is
-      <a href="https://indico.cern.ch/event/1150631/abstracts/">open</a> until Auguest 10 for you to submit live tutorial ideas or "notebook talks".
+    <p> After the huge success of PyHEP as virtual events since 2020, the workshop is back, again as a virtual event. The call for abstracts is
+      <a href="https://indico.cern.ch/event/1150631/abstracts/">open</a> until August 10 for you to submit live tutorial ideas, "notebook talks"
+      or lightning talks.
     </p>
    </div>
 

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -62,22 +62,14 @@ in High Energy Physics software and computing internationally.
 
 
   <div class="col-lg-4">
-    <h2>Analysis Ecosystems Workshop II</h2>
+    <h2>PyHEP 2022</h2>
     <p>
-      Five years after the original Analysis Ecosystems Workshop in 
-      Amsterdam, the HSF and IRIS-HEP are organising the second
-      <a href="https://indico.cern.ch/e/aew2">Analysis Ecosystems Workshop</a>
-      at IJCLab in Paris from 23-25 May.
+      Registration for the <a href="https://indico.cern.ch/e/pyhep2022">PyHEP 2022 workshop</a> is now <a href="https://indico.cern.ch/event/1150631/registrations/82480/">open</a>.
     </p>
-    <p>
-      Much has happened since 2017 and
-      now is an ideal time to review progress and look at the future of
-      analysis at HL-LHC, DUNE, EIC, FAIR and other HEP experiments
-      at future facilities.
-    </p>
-    <p>
-      Registration is <a href="https://indico.cern.ch/event/1125222/registrations/">open now</a>
-      - sign up now to be part of the discussion on our analysis future.
+    <img src="/images/pyhep/PyHEP_logo_template_white.png"
+    alt="PyHEP-logo" style="display: block; width:55%; margin-left: auto; margin-right: auto;">
+    <p> After the huge success of PyHEP in 2021 the workshop is back, again as a virtual event. The call for abstracts is
+      <a href="https://indico.cern.ch/event/1150631/abstracts/">open</a> until Auguest 10 for you to submit live tutorial ideas or "notebook talks".
     </p>
    </div>
 
@@ -90,7 +82,7 @@ in High Energy Physics software and computing internationally.
           community through our  <a href="{{ '/forums.html' | relative_url }}">discussion forums</a>
           and <a href="{{ '/technical_notes.html' | relative_url }}">technical notes</a>.
           </p>
-      <p>The HSF can also write <a href="{{ '/organization/hsf-letters.html' | relative_url }}">letters 
+      <p>The HSF can also write <a href="{{ '/organization/hsf-letters.html' | relative_url }}">letters
         of collaboration and cooperation</a> to project proposals.</p>
    <p><a href="{{ '/get_involved.html' | relative_url }}" role="button">How to get involved &raquo;</a></p>
        </div>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -68,7 +68,7 @@ in High Energy Physics software and computing internationally.
     </p>
     <img src="/images/pyhep/PyHEP_logo_template_white.png"
     alt="PyHEP-logo" style="display: block; width:55%; margin-left: auto; margin-right: auto;">
-    <p> After the huge success of PyHEP as virtual events since 2020, the workshop is back, again as a virtual event. The call for abstracts is
+    <p>After the huge success of virtual PyHEP workshops since 2020, we are back, again as a virtual event. The call for abstracts is
       <a href="https://indico.cern.ch/event/1150631/abstracts/">open</a> until August 10 for you to submit live tutorial ideas, "notebook talks"
       or lightning talks.
     </p>


### PR DESCRIPTION
Adapted fully from a previous announcement. I will think later if small modifications are useful, and kindly do the same. We can certainly merge tomorrow when the workshop announcement email will go out :-).