### PR TITLE
fix: correct typo in Scikit-HEP  module

### DIFF
--- a/_data/training-modules.yaml
+++ b/_data/training-modules.yaml
@@ -172,7 +172,7 @@
   webpage: https://swcarpentry.github.io/shell-novice/
   id: unix
 - description: A collection of packages for particle physics analyses in Python.
-  name: SciKit HEP
+  name: Scikit-HEP
   status: beta
   videos: ''
   webpage: https://hsf-training.github.io/hsf-training-scikit-hep-webpage/


### PR DESCRIPTION
Correct spelling for the Scikit-HEP training module from `SciKit HEP` to `Scikit-HEP`