### PR TITLE
[GSoC] Enabling web-based avatars for blog authors.

### DIFF
--- a/_activities/gsoc.md
+++ b/_activities/gsoc.md
@@ -49,7 +49,10 @@ For further information, feel free to contact the HSF GSoC admins or join our op
 
 ### Student pages
 
-Student blogs are mandatory for CERN-HSF starting with 2022 GSoC edition! If you are a CERN-HSF student, please read this [blog]({{ site.baseurl }}/gsoc/2022/blogs.html).
+The CERN-HSF 2022 student blogs are now available. [Check them out!]({{ site.baseurl }}/gsoc/2022/blogs.html)
+
+Student blogs are mandatory for CERN-HSF starting with 2022 GSoC edition! If you are a CERN-HSF student, please read this [blog]({{ site.baseurl }}/gsoc/blogs/2022/blog_HSF_TheAdmins.html).
+
 
 ### For Projects and Mentors
 

--- a/_activities/gsoc.md
+++ b/_activities/gsoc.md
@@ -51,7 +51,7 @@ For further information, feel free to contact the HSF GSoC admins or join our op
 
 The CERN-HSF 2022 student blogs are now available. [Check them out!]({{ site.baseurl }}/gsoc/2022/blogs.html)
 
-Student blogs are mandatory for CERN-HSF starting with 2022 GSoC edition! If you are a CERN-HSF student, please read this [blog]({{ site.baseurl }}/gsoc/blogs/2022/blog_HSF_TheAdmins.html).
+Student blogs are mandatory for receiving a positive evaluation in CERN-HSF starting with 2022 GSoC edition! If you are a CERN-HSF student, please read this [blog]({{ site.baseurl }}/gsoc/blogs/2022/blog_HSF_TheAdmins.html).
 
 
 ### For Projects and Mentors

--- a/_gsocblogs/2022/blog_HSF_TheAdmins.md
+++ b/_gsocblogs/2022/blog_HSF_TheAdmins.md
@@ -3,6 +3,7 @@ project: HSF
 title: Writing a blog about your project with HSF in GSoC
 author: Andrei Gheata
 [//]: # (photo: blog_authors/FirstLast.jpg)
+avatar: https://avatars.githubusercontent.com/u/18400453?s=400&v=4
 date: 08.06.2022
 year: 2022
 layout: blog_post
@@ -28,9 +29,10 @@ We are still experimenting this year, so there are no formal rules. The idea is 
 
 ---
 **project:** HSF _<span style="color:grey"> [replace with the project label as in _gsocprojects/YEAR/project_yourproject.md]</span>_<br/>
-**title:** Your article title<br/>
+**title:** Your article title. This is generally your project name.<br/>
 **author:** Jane Doe<br/>
-**photo:** blog_authors/JaneDoe.jpg _<span style="color:grey"> [Optionally use this label and upload a squared format photo as images/blog_authors/FirstLast.jpg]</span>_<br/>
+**photo:** blog_authors/JaneDoe.jpg _<span style="color:grey"> [Upload a squared format photo or avatar in the folder images/blog_authors/FirstLast.jpg]</span>_<br/>
+**avatar:** https://avatars.githubusercontent.com/u/[user_id]?s=400&v=4 _<span style="color:grey"> [Use a web-based avatar instead of a photo. To use your github avatar, go to your github profile and copy the address of your avatar image, then paste it after the label, changing the size value to s=400]</span>_<br/>
 **date:** 16.05.2022 _<span style="color:grey"> [Use the date when you wrote the article]</span>_<br/>
 **year:** 2022 _<span style="color:grey"> [Make sure the year is the current one]</span>_<br/>
 **layout:** blog_post<br/>

--- a/_layouts/blog_post.html
+++ b/_layouts/blog_post.html
@@ -8,15 +8,22 @@ layout: default
 
 <div class="blog-header">
   <div class="row">
-    {% if page.photo %} 
-    <div class="col-md-3">
-      <img src="{{ site.baseurl }}/images/{{ page.photo }}" alt={{ page.author }} width="100%" style="float:right">
-    </div>
-    <div class="col-md-9">
+    {% if page.avatar %}
+      <div class="col-md-3">
+        <img src="{{ page.avatar }}" alt={{ page.author }} width="100%" style="float:right">
+      </div>
+      <div class="col-md-9">
     {% else %}
-    <div class="col-md-12">
+      {% if page.photo %} 
+        <div class="col-md-3">
+          <img src="{{ site.baseurl }}/images/{{ page.photo }}" alt={{ page.author }} width="100%" style="float:right">
+        </div>
+        <div class="col-md-9">
+      {% else %}
+        <div class="col-md-12">
+      {% endif %}
     {% endif %}
-      <h1 class="blog-title">{{ page.title }}</h1>
+    <h1 class="blog-title">{{ page.title }}</h1>
     </div>
   </div>
   <p class="blog-post-meta">{{ page.date | date_to_string }} by <a href="{{ page.url }}">{{ page.author }}</a></p>

--- a/gsoc/2022/blogs.md
+++ b/gsoc/2022/blogs.md
@@ -17,8 +17,12 @@ year: 2022
       <h2>{{ blog.title }}</h2>
     </div> 
     <div class="col-sm-3" style="text-align: center;">
-      {% if blog.photo %}
-      <img src="/images/{{ blog.photo }}" alt="{{ blog.author }}" width="100px">
+      {% if blog.avatar %}
+      <img src="{{ blog.avatar }}" alt="{{ blog.author }}" width="100px">
+      {% else %}
+        {% if blog.photo %}
+        <img src="/images/{{ blog.photo }}" alt="{{ blog.author }}" width="100px">
+        {% endif %}
       {% endif %}
       <p style="font-weight: bold; text-align: center; font-style: oblique;"> {{ blog.author }}</p> 
     </div>


### PR DESCRIPTION
This enables the label `avatar` for GSoC blogs, allowing the use of an avatar link such as the personal one on GitHub for authors who do not want to upload a personal photo. The GSoC admins' blog advertising how blogs should be written uses this feature.