### PR TITLE
Fix superfluous div in new year for list of educators

### DIFF
--- a/_includes/list_of_educators.html
+++ b/_includes/list_of_educators.html
@@ -14,11 +14,14 @@ github.com.com/carpentries/carpentries.org/gh-pages/_includes/community_profiles
 We need to keep track of how many educators are skipped in order to have the
 proper index for the table column. -->
 {% assign skipped = 0 %}
+{% assign educators_added = false %}
 {% for person in site.profiles| sort:"title" %}
 {% unless person.training_years contains loopyear %}
 {% assign skipped = skipped | plus: -1 %}
 {% continue %}
-{% endunless %}
+{% else %}
+{% assign educators_added = true %}
+{% endif %}
 
 {% assign column = forloop.index | plus: skipped | modulo: 4 %}
 
@@ -43,7 +46,7 @@ proper index for the table column. -->
 
 {% endfor %}
 
-{% unless column == 0 %}
+{% unless column == 0 or educators_added == false %}
 <!-- The last </div> never happened, because we ended short of a full last column. -->
 <!-- Small bug: If there is no educator for a whole year, then this will still get displayed.... -->
 </div>

--- a/_includes/list_of_educators.html
+++ b/_includes/list_of_educators.html
@@ -19,6 +19,7 @@ proper index for the table column. -->
 {% unless person.training_years contains loopyear %}
 {% assign skipped = skipped | plus: -1 %}
 {% continue %}
+{% endunless %}
 {% else %}
 {% assign educators_added = true %}
 {% endif %}

--- a/_includes/list_of_educators.html
+++ b/_includes/list_of_educators.html
@@ -19,10 +19,10 @@ proper index for the table column. -->
 {% unless person.training_years contains loopyear %}
 {% assign skipped = skipped | plus: -1 %}
 {% continue %}
-{% endunless %}
+
 {% else %}
 {% assign educators_added = true %}
-{% endif %}
+{% endunless %}
 
 {% assign column = forloop.index | plus: skipped | modulo: 4 %}
 


### PR DESCRIPTION
#1260 
To fix this bug, I added a check at the end of the inner loop (the one that loops through the educators) to see if any educators have been added to the current year. To accomplish this I added a variable, educators_added, that is set to false at the start of the inner loop, and then set to true whenever an educator is added to the current year. At the end of the inner loop, I check if educators_added is true and if so, added the closing div. If not, skipped the closing div.

I also added a else statement inside the unless loop that checks for the year, where I added the line to set the variable educators_added to true.

I also added a unless statement which checks whether the last column was full or not and also whether any educators were added in that year or not. If the column was not full and no educators were added, then it skips the closing div.