### PR TITLE
Add MCnet project, UGlasgow org, and LHAPDF proposal

### DIFF
--- a/_gsocorgs/2023/uglasgow.md
+++ b/_gsocorgs/2023/uglasgow.md
@@ -1,0 +1,11 @@
+---
+title: "University of Glasgow"
+author: "Andy Buckley"
+layout: default
+organization: UofGlasgow
+logo: UGlasgow-logo.png
+description: |
+  The [University of Glasgow](https://www.gla.ac.uk/) is a leading UK research university based in Scotland's largest city. We work on [particle physics experiments](https://www.gla.ac.uk/schools/physics/research/groups/particlephysicsexperiment/) from the LHC to neutrinos, particle theory from interpretations of Higgs and top-quark measurements to the strong force, and high-performance distributed computing.
+---
+
+{% include gsoc_proposal.ext %}

--- a/_gsocprojects/2023/project_MCnet.md
+++ b/_gsocprojects/2023/project_MCnet.md
@@ -1,0 +1,24 @@
+---
+project: MCnet
+title: MCnet
+layout: default
+logo: mcnet-logo.png
+description: |
+    [MCnet](http://montecarlonet.org) is a collaboration between the developers of
+    the major collision-event modelling tools used at the [Large Hadron
+    Collider](http://home.web.cern.ch/topics/large-hadron-collider) (LHC) and
+    beyond. These codes are so-called "MC event generators", theoretical physics
+    packages that perform quantum mechanics calculations and create simulated
+    particle collisions. MC generators are an essential component
+    of both modern particle physics experiments and theory, and provide a crucial
+    bridge between those two communities. MCnet projects include both event
+    generators themselves, and tools that connect them to both experiment and
+    theory.
+summary: |
+    [MCnet](http://montecarlonet.org) is a community linking the developers of
+    particle-theory simulations with experimentalists and others who use and
+    make tools for analysing the simulated events. Projects may be available
+    from both aspects of the community.
+---
+
+{% include gsoc_project.ext %}

--- a/_gsocproposals/2023/proposal_MCnetLHAPDF.md
+++ b/_gsocproposals/2023/proposal_MCnetLHAPDF.md
@@ -1,0 +1,73 @@
+---
+title: MCnet/LHAPDF - Test suite and coverage for parton density calculations
+layout: gsoc_proposal
+project: MCnet
+year: 2023
+organization:
+  - UofGlasgow
+difficulty: easy
+duration: 175
+mentor_avail: June-October
+---
+
+# Description
+
+The Large Hadron Collider smashes protons into each other at the highest
+energies humanity has ever engineered. Protons are a very convenient type of
+particle for our high-energy beams : they are plentiful, and they don't lose
+(lots of) energy like electrons do when accelerated around the LHC ring. But
+they are not *fundamental* particles: they are made up of a tightly bound
+collection of smaller particles, and to make the most out of LHC experiments we
+need to understand both what we do and don't know about the internal structure
+of the proton that these objects induce. We encode this through so-called parton
+density functions, or PDFs.
+
+The [LHAPDF](https://lhapdf.hepforge.org) C++ library is the LHC's standard
+system for supplying PDF data to both experiments and theory
+calculations. Several years ago it was rewritten from scratch to make it more
+flexible and maintainable, but extensions are now needed. This project will put
+in place a far more complete regression-testing suite and code-coverage
+monitoring to ensure that these new developments preserve the current behaviours,
+which the whole LHC programme depends on being stable.
+
+
+## Task ideas
+
+This project will add continuous-integration (CI) tests in the GitLab system, to
+ensure that all aspects of the LHAPDF calculations are tested on a scalable rota,
+and introduce CI testing of code quality. The intention is to ensure the
+stability of LHAPDF established behaviours to high precision, to give required
+confidence when making new releases and developing new features. The project can
+also include more physics-oriented work for a suitable candidate.
+
+
+## Expected results and milestones
+
+ * Familiarise with the LHAPDF framework from interface to calculation components;
+ * Familiarise with current LHAPDF CI tests and the GitLab config system;
+ * Design and present a new proposal of CI tests to provide feature coverage,
+   with a CPU-efficient test schedule, targetting of change-driven tests, and
+   a full-suite pre-release test-set;
+ * Set up a Mac-based CI test worker, either virtual or physical, and incorporate
+   in the test system;
+ * Incorporate a trial SonarCloud scan of the LHAPDF codebase, to identify code
+   quality issues.
+
+
+## Requirements
+
+ * C++
+ * Python
+ * CI testing
+ * git
+
+
+## Mentors
+
+ * **[Andy Buckley](mailto:andy.buckley@cern.ch)**
+ * [Max Knobbe](mailto:max.knobbe@uni-goettingen.de)
+
+
+## Links
+
+ * [LHAPDF](https://lhapdf.hepforge.org)

--- a/_gsocproposals/2023/proposal_MCnetLHAPDF.md
+++ b/_gsocproposals/2023/proposal_MCnetLHAPDF.md
@@ -46,7 +46,7 @@ also include more physics-oriented work for a suitable candidate.
  * Familiarise with the LHAPDF framework from interface to calculation components;
  * Familiarise with current LHAPDF CI tests and the GitLab config system;
  * Design and present a new proposal of CI tests to provide feature coverage,
-   with a CPU-efficient test schedule, targetting of change-driven tests, and
+   with a CPU-efficient test schedule, targeting of change-driven tests, and
    a full-suite pre-release test-set;
  * Set up a Mac-based CI test worker, either virtual or physical, and incorporate
    in the test system;

--- a/gsoc/2023/mentors.md
+++ b/gsoc/2023/mentors.md
@@ -7,5 +7,6 @@ layout: plain
 
 ## Full Mentor List (Name, Email, Org)
 * Jack Y. Araz [jack.araz@durham.ac.uk](mailto:jack.araz@durham.ac.uk) IPPP
+* Andy Buckley [andy.buckley@gla.ac.uk](mailto:andy.buckley@gla.ac.uk) UofGlasgow
 * Benjamin Fuks [fuks@lpthe.jussieu.fr](mailto:fuks@lpthe.jussieu.fr) LPTHE
 * Benedikt Hegner [benedikt.hegner@cern.ch](mailto:benedikt.hegner@cern.ch) CERN


### PR DESCRIPTION
A new proposal for LHAPDF work, re-enabling MCnet and UGlasgow to support.