### PR TITLE
Implemented conditional display of school list title based on emptiness.

### DIFF
--- a/Schools/events.md
+++ b/Schools/events.md
@@ -3,9 +3,12 @@ layout: plain
 title: HEP Software Training Events
 ---
 
-## Current and Upcoming Training Events
+{% capture list_of_upcoming_schools %}{% include list_of_upcoming_schools.md %}{% endcapture %}
+{% if list_of_upcoming_schools != "" %}
+  ## Current and Upcoming Training Events
 
-{% include list_of_upcoming_schools.md %}
+  {{ list_of_upcoming_schools }}
+{% endif %}
 
 ## Past Events
 


### PR DESCRIPTION
**Problem statement:** https://hepsoftwarefoundation.org/Schools/events.html: The current/upcoming section is shown even without corresponding events. **_Issue: #1298_**
To ensure that the title is only displayed when the list of upcoming schools in "list_of_upcoming_schools.md" is not empty, a conditional statement is added in the "events.md" file. The statement checks the emptiness of the list and only displays the title if it is not empty.