### PR TITLE
Fixed the display issue of superfluous closing div element in profile grid

### DIFF
--- a/Schools/events.md
+++ b/Schools/events.md
@@ -3,9 +3,12 @@ layout: plain
 title: HEP Software Training Events
 ---
 
-## Current and Upcoming Training Events
+{% capture list_of_upcoming_schools %}{% include list_of_upcoming_schools.md %}{% endcapture %}
+{% if list_of_upcoming_schools != "" %}
+  ## Current and Upcoming Training Events
 
-{% include list_of_upcoming_schools.md %}
+  {{ list_of_upcoming_schools }}
+{% endif %}
 
 ## Past Events
 

--- a/Schools/events.md
+++ b/Schools/events.md
@@ -4,9 +4,9 @@ title: HEP Software Training Events
 ---
 
 {% capture list_of_upcoming_schools %}{% include list_of_upcoming_schools.md %}{% endcapture %}
-{% if list_of_upcoming_schools != "" %}
+{% capture test %}{{ list_of_upcoming_schools | strip }}{% endcapture %}
+{% if test  != "" %}
   ## Current and Upcoming Training Events
-
   {{ list_of_upcoming_schools }}
 {% endif %}
 

--- a/_includes/list_of_educators.html
+++ b/_includes/list_of_educators.html
@@ -2,10 +2,16 @@
 
 <!-- Start looping through all the years that we have educators for.
 The first year is hard coded here. -->
+
 {% assign firstyear = 2019 %}
 {% assign currentyear = site.time | date: '%Y' %}
 {% for loopyear in (firstyear..currentyear) reversed %}
-<h3 id="{{ loopyear }}"> {{ loopyear }} </h3>
+
+  <h3 id="{{ loopyear }}"> {{ loopyear }} </h3>
+  {% assign educators_in_current_year = 0 %}
+  {% assign skipped = 0 %}
+  {% for person in site.profiles| sort:"title" %}
+    {% unless person.training_years contains loopyear %}
 
 <!-- Now we loop through the educators, sorted by their full names and
 pick out the ones who trained in $loopyear.
@@ -13,40 +19,34 @@ This code originally was based on
 github.com.com/carpentries/carpentries.org/gh-pages/_includes/community_profiles.md
 We need to keep track of how many educators are skipped in order to have the
 proper index for the table column. -->
-{% assign skipped = 0 %}
-{% for person in site.profiles| sort:"title" %}
-{% unless person.training_years contains loopyear %}
-{% assign skipped = skipped | plus: -1 %}
-{% continue %}
-{% endunless %}
 
-{% assign column = forloop.index | plus: skipped | modulo: 4 %}
-
-{% if column == 1 %}
-<div class="row">
-{% endif %}
+      {% assign skipped = skipped | plus: -1 %}
+      {% continue %}
+    {% endunless %}
+    {% assign educators_in_current_year = educators_in_current_year + 1 %}
+    {% assign column = forloop.index | plus: skipped | modulo: 4 %}
+    {% if column == 1 %}
+      <div class="row">
+    {% endif %}
 
 <!-- to do delayed loading etc., see https://www.ratanparai.com/jekyll/Responsive-image-on-jekyll/ and then the original carpentries template -->
 
-<div class="medium-3 columns">
-<div class="team-member anchor-offset" id="{{ person.github }}">
-<a href="{{ person.url }}">{% include profile_avatar.html %}</a>
-{% include educator_badges.html %}
-<h3><a href="{{ person.url }}">{{ person.title }}</a></h3>
-{% include profile_social.html %}
-</div>
-</div>
-
-{% if column == 0 %}
-</div>
-{% endif %}
-
+    <div class="medium-3 columns">
+      <div class="team-member anchor-offset" id="{{ person.github }}">
+        <a href="{{ person.url }}">{% include profile_avatar.html %}</a>
+        {% include educator_badges.html %}
+        <h3><a href="{{ person.url }}">{{ person.title }}</a></h3>
+        {% include profile_social.html %}
+      </div>
+    </div>
+    {% if column == 0 %}
+      </div>
+    {% endif %}
+  {% endfor %}
+  {% if educators_in_current_year == 0 %}
+    {% assign column = 0 %}
+  {% endif %}
+  {% unless column == 0 %}
+    </div>
+  {% endunless %}
 {% endfor %}
-
-{% unless column == 0 %}
-<!-- The last </div> never happened, because we ended short of a full last column. -->
-<!-- Small bug: If there is no educator for a whole year, then this will still get displayed.... -->
-</div>
-{% endunless %}
-{% endfor %}
-


### PR DESCRIPTION
**Problem Statement:** If a new year starts and now educator has been registered for that year, a superfluous </div> is printed (see also comment at the bottom of the page). **Issue:** #1260

A Conditional statement and a new variable _educators_in_current_year_ have been added to keep track of the number of educators registered for each year. The code now checks if there are any educators registered for the current year before printing the closing div element. This ensures that the closing _div_ element is only printed if there are educators to display, and eliminates the issue of a superfluous closing div element being printed.