### PR TITLE
patatrack gsoc proposal: fix missing whitespace in yaml

### DIFF
--- a/_gsocprojects/2023/project_Patatrack.md
+++ b/_gsocprojects/2023/project_Patatrack.md
@@ -3,7 +3,7 @@ project: Patatrack
 layout: default
 logo: patatrack-logo.png
 description: |
-The [Patatrack](https://patatrack.web.cern.ch/patatrack/index.html) project started in 2016 by a group of people with various area of expertise, such as software optimization, heterogeneous computing, track reconstruction and High Level Trigger (HLT) at the CMS experiment at CERN. The goal was to demonstrate that part of the HLT reconstruction could be efficiently offloaded on machines equipped with GPUs for parallel execution. Nowadays, Patatrack developments have been integrated into the CMS software for event reconstruction and the project focuses on the exploration of innovative software and hardware technologies to bring smart software closer to the detector read-out at CERN experiments.
+  The [Patatrack](https://patatrack.web.cern.ch/patatrack/index.html) project started in 2016 by a group of people with various area of expertise, such as software optimization, heterogeneous computing, track reconstruction and High Level Trigger (HLT) at the CMS experiment at CERN. The goal was to demonstrate that part of the HLT reconstruction could be efficiently offloaded on machines equipped with GPUs for parallel execution. Nowadays, Patatrack developments have been integrated into the CMS software for event reconstruction and the project focuses on the exploration of innovative software and hardware technologies to bring smart software closer to the detector read-out at CERN experiments.
 ---
 
 {% include gsoc_project.ext %}


### PR DESCRIPTION
https://github.com/HSF/hsf.github.io/pull/1337 does not render correctly at the moment at https://hepsoftwarefoundation.org/activities/gsoc.html - this should fix it.