### PR TITLE
GSoC proposal: CERNBox Notifications

### DIFF
--- a/_gsocprojects/2023/project_CERNBox.md
+++ b/_gsocprojects/2023/project_CERNBox.md
@@ -1,0 +1,14 @@
+---
+project: CERNBox
+title: CERNBox
+layout: default
+logo: cernbox-logo.png
+description: |
+   [CERNBox](http://cernbox.web.cern.ch) is a cloud synchronisation service for
+   end-users: it allows syncing and sharing files on all major mobile and
+   desktop platforms (Linux, Windows, MacOSX, Android, iOS) aiming to provide
+   offline availability to any data stored in the [CERN EOS](http://eos.web.cern.ch)
+   infrastructure.
+---
+
+{% include gsoc_project.ext %}

--- a/_gsocproposals/2023/proposal_CERNBox-notifications.md
+++ b/_gsocproposals/2023/proposal_CERNBox-notifications.md
@@ -47,7 +47,8 @@ The scope and extent of the improvements will be tailored to the skills / availa
 
 
 ## Mentors
-* **[Javier Ferrer](mailto:javier.ferrer@cern.ch)**
+* **[Javier Ferrer](mailto:javier.ferrer@cern.ch)** CERN
+* [Hugo Gonzalez Labrador](mailto:hugo.gonzalez.labrador@cern.ch) CERN
 
 
 ## Links

--- a/_gsocproposals/2023/proposal_CERNBox-notifications.md
+++ b/_gsocproposals/2023/proposal_CERNBox-notifications.md
@@ -27,7 +27,7 @@ This Student Proposal aims to extend the capabilities of Reva’s notification s
 * Provide a richer set of actions for the notification API (filters, delayed actions, metrics)
 * Create documentation for the new features
 
-Any ideas the student comes up while working on the project are welcome!
+Any ideas the student comes up with while working on the project are welcome!
 
 
 ## Expected results

--- a/_gsocproposals/2023/proposal_CERNBox-notifications.md
+++ b/_gsocproposals/2023/proposal_CERNBox-notifications.md
@@ -1,0 +1,55 @@
+---
+title: Extend and improve the CERNBox Notifications platform
+layout: gsoc_proposal
+project: CERNBox
+year: 2023
+difficulty: medium
+duration: 175
+mentor_avail: June-September
+organization:
+  - CERN
+---
+
+
+## Description
+
+[CERNBox](https://cernbox.web.cern.ch) is a sync and share collaborative cloud storage solution developed at CERN, used by more than 37K users and storing over 18PB of data.
+
+[Reva](https://github.com/cernbox/reva) is the core of the CERNBox service. It is a middleware framework, providing interoperability between storage and application providers using a universal set of APIs. This enables CERNBox to connect to an array of storages, allowing collaborative data services and applications to function at a large scale.
+
+This Student Proposal aims to extend the capabilities of Reva’s notification system with more features to improve the user experience and the programmers' available API.
+
+
+## Task ideas
+
+* Extend the simple notifications in the Web front-end into a notifications center
+* Implement a Mattermost notification extension
+* Provide a richer set of actions for the notification API (filters, delayed actions, metrics)
+* Create documentation for the new features
+
+Any ideas the student comes up while working on the project are welcome!
+
+
+## Expected results
+
+The scope and extent of the improvements will be tailored to the skills / available time of the student. We expect that at the conclusion of the project, the agreed upon new features of the CERNBox notification system will be implemented.
+
+
+## Requirements
+* Mandatory
+  * Go and JavaScript (ES2020+)
+  * Git
+  * REST APIs
+* Good to have
+  * Distributed systems
+  * VueJS
+  * RDBMS (mySQL)
+
+
+## Mentors
+* **[Javier Ferrer](mailto:javier.ferrer@cern.ch)**
+
+
+## Links
+* [CERNBox project](https://cernbox.web.cern.ch)
+* [Reva project](https://github.com/cs3org/reva)

--- a/gsoc/2023/mentors.md
+++ b/gsoc/2023/mentors.md
@@ -16,6 +16,7 @@ layout: plain
 * Wouter Deconinck [wouter.deconinck@umanitoba.ca](mailto:wouter.deconinck@umanitoba.ca) UManitoba
 * Caterina Doglioni [caterina.doglioni@cern.ch](mailto:caterina.doglioni@cern.ch) UofManchester
 * Alexander Ekman [alexander.ekman@hep.lu.se](mailto:alexander.ekman@hep.lu.se) LundU
+* Javier Ferrer [javier.ferrer@cern.ch](mailto:javier.ferrer@cern.ch) CERN
 * Benjamin Fuks [fuks@lpthe.jussieu.fr](mailto:fuks@lpthe.jussieu.fr) LPTHE
 * Benedikt Hegner [benedikt.hegner@cern.ch](mailto:benedikt.hegner@cern.ch) CERN
 * Thomas Kuhr [Thomas.Kuhr@lmu.de](mailto:Thomas.Kuhr@lmu.de) LMU

--- a/gsoc/2023/mentors.md
+++ b/gsoc/2023/mentors.md
@@ -18,6 +18,7 @@ layout: plain
 * Alexander Ekman [alexander.ekman@hep.lu.se](mailto:alexander.ekman@hep.lu.se) LundU
 * Javier Ferrer [javier.ferrer@cern.ch](mailto:javier.ferrer@cern.ch) CERN
 * Benjamin Fuks [fuks@lpthe.jussieu.fr](mailto:fuks@lpthe.jussieu.fr) LPTHE
+* Hugo Gonzalez Labrador [hugo.gonzalez.labrador@cern.ch](mailto:hugo.gonzalez.labrador@cern.ch) CERN
 * Benedikt Hegner [benedikt.hegner@cern.ch](mailto:benedikt.hegner@cern.ch) CERN
 * Thomas Kuhr [Thomas.Kuhr@lmu.de](mailto:Thomas.Kuhr@lmu.de) LMU
 * Baidyanath Kundu [baidyanath.kundu@cern.ch](mailto:baidyanath.kundu@cern.ch) CompRes


### PR DESCRIPTION
# 2023 GSoC Proposal for CERNBox

Adds: 
* New 2023 project: CERNBox
* New 2023 GSoC proposal: Extend and improve the CERNBox Notifications platform
