### PR TITLE
Fix codespell ignore list

### DIFF
--- a/codespell.txt
+++ b/codespell.txt
@@ -12,5 +12,5 @@ arithmetics
 espace
 commends
 ro
-Parth
-CompRes
+parth
+compres


### PR DESCRIPTION
Fixing ineffective #1349. The ignore-listed words must always be lowercase AFAIK
