### PR TITLE
Add missing organisation label in cea-irfu.md

### DIFF
--- a/_gsocorgs/2023/cea-irfu.md
+++ b/_gsocorgs/2023/cea-irfu.md
@@ -2,7 +2,7 @@
 title: "CEA-IRFU"
 author: "Pere Mato"
 layout: default
-organization: 
+organization: CEA-IRFU
 logo: CEA-logo.png
 description: |
   The [IRFU](https://irfu.cea.fr), Institute for Research on the fundamental laws of the universe, of the Fundamental Research Division of the [CEA](https://www.cea.fr), brings together three scientific disciplines, astrophysics, nuclear physics and particle physics, as well as all the associated technological expertise.


### PR DESCRIPTION
Hello,

This PR fills the organisation field in the cea-irfu.md file. The empty field might explain why the [CEA-IRFU project list](https://hepsoftwarefoundation.org/gsoc/organizations/2023/cea-irfu.html) is empty. The list is expected to contain one project proposed jointly with CERN, with @peremato and myself as mentors ([Julia interoperating with HEP C++ libraries](https://hepsoftwarefoundation.org/gsoc/2023/proposal_Julia-HEP-Cpp.html),   PR #1340)

@hegner could you check that this PR fix the issue and do necessary changes if not?

Thanks,
Philippe.