### PR TITLE
Fix link checker (default branch changed)

### DIFF
--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -21,3 +21,4 @@ jobs:
           config-file: '.github/config/mdcheck.json'
           check-modified-files-only: 'yes'
           use-verbose-mode: 'yes'
+          base-branch: 'main'


### PR DESCRIPTION
The default branch needs to be specified explicitly, because we diff to that to only check modified files (see [docs](https://github.com/gaurav-nelson/github-action-markdown-link-check#check-only-modified-files-in-a-pull-request))