### PR TITLE
recotrigger working group: updating to 2023 conveners

### DIFF
--- a/_workinggroups/recotrigger.md
+++ b/_workinggroups/recotrigger.md
@@ -25,12 +25,12 @@ of profiling and quality assurance toolkits.
 ## Get involved
 
 Current WG conveners:
+- Christina Agapopoulou (LHCb, CERN)
+- Claire Antel (ATLAS/FASER, Uni Geneva)
+- Giulia Casarosa (Belle II, Università di Pisa)
 
-- Andreas Salzburger (ATLAS, CERN)
-- Jin Huang (sPHENIX/EIC, BNL)
-- Dorothea vom Bruch (LHCb, CPPM)
 
-[Contact the group conveners](mailto:dorothea.vom.bruch@cern.ch,andreas.salzburger@cern.ch,jhuang@bnl.gov) by email. <!-- markdown-link-check-disable-line -->
+[Contact the group conveners](mailto:christina.agapopoulou@cern.ch,claire.antel@cern.ch,giulia.casarosa@pi.infn.it) by email. <!-- markdown-link-check-disable-line -->
 
 Everyone is welcome to participate and contribute on the forum and to the ongoing meetings. For more information, contact us or
 follow our mailing list on google groups [hsf-recotrigger](https://groups.google.com/forum/#!forum/hsf-recotrigger).
@@ -46,6 +46,9 @@ follow our mailing list on google groups [hsf-recotrigger](https://groups.google
 
 ## Former Conveners
 
+- Andreas Salzburger (ATLAS, CERN), 2021-2022
+- Jin Huang (sPHENIX/EIC, BNL), 2021-2022
+- Dorothea vom Bruch (LHCb, CPPM), 2021-2022
 - Caterina Doglioni (ATLAS), 2019-2020
 - Agnieszka Dziurda (LHCb), 2019-2020
 - David Lange (CMS), 2019-2021


### PR DESCRIPTION
Updating names and email addresses of current conveners for Reconstruction and Software Triggers Working Group.
Added previous conveners to "Former Conveners".