### PR TITLE
fix: rm twitter inset since non-operational

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -96,15 +96,3 @@ in High Energy Physics software and computing internationally.
 
   </div>
 </div>
-
-<div class="row" style="margin-top: 30px">
-
-  <div class="col-lg-3"></div>
-
-  <div class="col-lg-6">
-    <a class="twitter-timeline" style="margin: auto;" data-width="500" data-height="800" href="https://twitter.com/hepsoftfound?ref_src=twsrc%5Etfw">Tweets by hepsoftfound</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
-  </div>
-
-  <div class="col-lg-3"></div>
-</div>
-


### PR DESCRIPTION
This removes the twitter inset that doesn't show anything useful due to twitter policy changes (see below). We could replace it with a link to the twitter profile and other social profiles, but I don't think that would necessarily fit with the layout here.

![image](https://github.com/HSF/hsf.github.io/assets/4656391/98e0cfa2-f0f9-4bdc-b5eb-dc63aadded76)
