### PR TITLE
Rename curriculum.md -> center.md

### DIFF
--- a/_training/center.md
+++ b/_training/center.md
@@ -1,6 +1,8 @@
 ---
 title: HSF Software Training Center
 layout: plain
+redirect-from:
+- /training/curriculum
 ---
 
 <script defer data-domain="hepsoftwarefoundation.org" src="https://views.scientific-python.org/js/script.js"></script>


### PR DESCRIPTION
We call it "Training Center" since ages now, it's time that we have the corresponding URL.

With the redirect-from frontmatter, all old links will continue to work.