### PR TITLE
Add training modules from other initiatives

### DIFF
--- a/_data/training-modules.yaml
+++ b/_data/training-modules.yaml
@@ -1,3 +1,10 @@
+- description: 'This course covers various best practices like testing, pytest, object oriented programming, packing, CI, and more.'
+  name: "Software Engineering for Scientific Computing"
+  repository: https://github.com/henryiii/se-for-sci
+  status: stable
+  videos: ''
+  webpage: https://henryiii.github.io/se-for-sci/
+  id: se-for-sci
 - description: 'Track code changes, undo mistakes, collaborate. This module is a must.'
   name: Version controlling with git
   repository: https://github.com/swcarpentry/git-novice

--- a/_data/training-modules.yaml
+++ b/_data/training-modules.yaml
@@ -108,7 +108,7 @@
 - description: E.g. <code>yadage</code> and <code>reana</code>
   name: Workflows &amp; reproducibility
   repository: ''
-  status: alpha
+  status: stable
   videos: ''
   webpage: ''
   id: yadagereana

--- a/_data/training-modules.yaml
+++ b/_data/training-modules.yaml
@@ -1,3 +1,10 @@
+- description: 'Learn about ROOT, RooFit, machine learning with TMVA, and physics simulations.'
+  webpage: https://gitlab.com/stroche/particle-physics-methods
+  name: "Particle physics methods"
+  repository: https://gitlab.com/stroche/particle-physics-methods
+  id: root-analysis
+  videos: ''
+  status: beta
 - description: 'This course covers various best practices like testing, pytest, object oriented programming, packing, CI, and more.'
   name: "Software Engineering for Scientific Computing"
   repository: https://github.com/henryiii/se-for-sci

--- a/_training/curriculum.md
+++ b/_training/curriculum.md
@@ -31,7 +31,7 @@ The curriculum is comprised of a set of standardized *modules*, so that students
 
 ### HEP specific tools
 
-{% include list_of_selected_training_modules.html ids="scikithep,root,unroot,reana" %}
+{% include list_of_selected_training_modules.html ids="scikithep,root,unroot,reana,root-analysis" %}
 
 ### Analysis preservation
 

--- a/_training/curriculum.md
+++ b/_training/curriculum.md
@@ -19,7 +19,7 @@ The curriculum is comprised of a set of standardized *modules*, so that students
 
 ### Software Development and Deployment
 
-{% include list_of_selected_training_modules.html ids="git,advancedgit,cicd,cicdgithub,docker,singularity,testingpython,levelupyourpython" %}
+{% include list_of_selected_training_modules.html ids="git,advancedgit,cicd,cicdgithub,docker,singularity,testingpython,levelupyourpython,se-for-sci" %}
 
 ### C++ corner
 


### PR DESCRIPTION
The added modules are of somewhat different format, but they cover blindspots that the HSF modules have. 

Also it marks the reana training as stable (we've had a student walk through all of them and he didn't have issues)
