### PR TITLE
Add LHCb Analysis Essentials and "Complete courses" section

### DIFF
--- a/_data/training-modules.yaml
+++ b/_data/training-modules.yaml
@@ -1,3 +1,10 @@
+- description: 'From python, shell, and git to reproducible analyses with Snakemake. Written for LHCb, but applicable to everyone.'
+  webpage: https://hsf-training.github.io/analysis-essentials/
+  name: "LHCb Analysis Essentials"
+  repository: https://github.com/hsf-training/analysis-essentials/
+  id: lhcb-analysis-essentials
+  videos: ''
+  status: stable
 - description: 'Learn about ROOT, RooFit, machine learning with TMVA, and physics simulations.'
   webpage: https://gitlab.com/stroche/particle-physics-methods
   name: "Particle physics methods"

--- a/_training/center.md
+++ b/_training/center.md
@@ -33,6 +33,12 @@ See [below](#bkginfo) for more information about the modules listed here.
 
 {% include list_of_selected_training_modules.html ids="git,cicd,cicdgithub,docker,singularity,testingpython,reana" %}
 
+### Complete courses
+
+These modules cover a variety of topics.
+
+{% include list_of_selected_training_modules.html ids="se-for-sci,levelupyourpython,root-analysis,lhcb-analysis-essentials" %}
+
 ### Miscellaneous
 
 {% include list_of_selected_training_modules.html ids="simpleanalysis" %}


### PR DESCRIPTION
The LHCb training material is mostly not LHCb specific at all and is a really nice resource that is hosted in our organization. Since it covers so much, I added a new section for such "curricula in itself". 