### PR TITLE
Add training center version for embedding as iframe

### DIFF
--- a/_includes/training_center.html
+++ b/_includes/training_center.html
@@ -1,0 +1,39 @@
+### Basics
+
+{% include list_of_selected_training_modules.html ids="unix,git,python,ssh,ml,matplotlib,root" %}
+
+### Software Development and Deployment
+
+{% include list_of_selected_training_modules.html ids="git,advancedgit,cicd,cicdgithub,docker,singularity,testingpython,levelupyourpython,se-for-sci" %}
+
+### C++ corner
+
+{% include list_of_selected_training_modules.html ids="hepcpp,cmake"%}
+
+### Machine learning and other analysis tools
+
+{% include list_of_selected_training_modules.html ids="ml,gpuml" %}
+
+### HEP specific tools
+
+{% include list_of_selected_training_modules.html ids="scikithep,root,unroot,reana,root-analysis" %}
+
+### Analysis preservation
+
+{% include list_of_selected_training_modules.html ids="git,cicd,cicdgithub,docker,singularity,testingpython,reana" %}
+
+### Complete courses
+
+These modules cover a variety of topics.
+
+{% include list_of_selected_training_modules.html ids="se-for-sci,levelupyourpython,root-analysis,lhcb-analysis-essentials" %}
+
+### Miscellaneous
+
+{% include list_of_selected_training_modules.html ids="simpleanalysis" %}
+
+### Planned, in early development, or archived
+
+{% include list_of_selected_training_modules.html ids="uproot" %}
+
+

--- a/_layouts/empty.html
+++ b/_layouts/empty.html
@@ -1,0 +1,22 @@
+<!-- Used for the training center iframe embedding -->
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
+    <title>{{ page.title }}</title>
+    <link rel="icon" type="image/x-icon" href="{{ '/images/hsf_logo_angled.png' | relative_url }}">
+
+    <!-- bootstrap framework -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.5/flatly/bootstrap.min.css">
+
+    <link rel="stylesheet" href="{{ '/css/hsf.css' | relative_url }}" type="text/css" />
+</head>
+<body>
+<div class="container">
+
+  {{ content }}
+
+</body>
+</html>

--- a/_training/center.md
+++ b/_training/center.md
@@ -9,43 +9,7 @@ redirect_from:
 
 See [below](#bkginfo) for more information about the modules listed here.
 
-### Basics
-
-{% include list_of_selected_training_modules.html ids="unix,git,python,ssh,ml,matplotlib,root" %}
-
-### Software Development and Deployment
-
-{% include list_of_selected_training_modules.html ids="git,advancedgit,cicd,cicdgithub,docker,singularity,testingpython,levelupyourpython,se-for-sci" %}
-
-### C++ corner
-
-{% include list_of_selected_training_modules.html ids="hepcpp,cmake"%}
-
-### Machine learning and other analysis tools
-
-{% include list_of_selected_training_modules.html ids="ml,gpuml" %}
-
-### HEP specific tools
-
-{% include list_of_selected_training_modules.html ids="scikithep,root,unroot,reana,root-analysis" %}
-
-### Analysis preservation
-
-{% include list_of_selected_training_modules.html ids="git,cicd,cicdgithub,docker,singularity,testingpython,reana" %}
-
-### Complete courses
-
-These modules cover a variety of topics.
-
-{% include list_of_selected_training_modules.html ids="se-for-sci,levelupyourpython,root-analysis,lhcb-analysis-essentials" %}
-
-### Miscellaneous
-
-{% include list_of_selected_training_modules.html ids="simpleanalysis" %}
-
-### Planned, in early development, or archived
-
-{% include list_of_selected_training_modules.html ids="uproot" %}
+{% include training_center.html %}
 
 ## <a name="bkginfo"></a>Additional information
 
@@ -54,6 +18,7 @@ Training in software and computing are essential ingredients for the success of 
 The curriculum is composed of a set of *modules* (developed by HSF, Software Carpentries, and other organizations), so that learners/students can focus on what is most relevant to them.
 
 * Show all modules in a table (mostly for administrative purposes): [click here]({{site.baseurl}}/training/curriculum_table.html)
+* Stripped down version of this page that can be included as an iframe: [click here]({{site.baseurl}}/training/center_iframe.html)
 * I want to **contribute** or **teach**:
 Contributions of any kind are very welcome! There are various ways you can get involved:
 

--- a/_training/center_iframe.md
+++ b/_training/center_iframe.md
@@ -1,0 +1,11 @@
+---
+layout: empty
+title: HSF Training Center
+---
+
+<script defer data-domain="hepsoftwarefoundation.org" src="https://views.scientific-python.org/js/script.js"></script>
+
+List of modules from the [HSF Training Center](https://hepsoftwarefoundation.org/training/center).
+
+{% include training_center.html %}
+


### PR DESCRIPTION
As suggested by @henryiii during the IRIS-HEP retreat, it might be nice to embed the training center at the pages of our partners. For this, this PR creates a "blank page" with only the modules present (no HSF header/footer), no other content. One target would be IRIS-HEP or INTERSECT sites.

This required some refactoring to avoid duplication.