### PR TITLE
Update gsdocs.md to add 2022 proposal link

### DIFF
--- a/_activities/gsdocs.md
+++ b/_activities/gsdocs.md
@@ -28,7 +28,7 @@ Since 2011, CERN has participated in other Google initiatives such as Google Sum
 ### Previous HSF Season of Docs Results 
 
   * 2020 Season of Docs Technical writer [blogs]({{ site.baseurl }}/gsdocs/2020/blogs.html)
-  * 2022 Season of Docs [summary]({{ site.baseurl }}/gsdocs/2022/Outcome.pdf)
+  * 2022 Season of Docs [summary]({{ site.baseurl }}/gsdocs/2022/Outcome.pdf) and [proposal]({{ site.baseurl }}/gsdocs/2022/proposal_analysis.html)
   
 ### For technical writers
 


### PR DESCRIPTION
google's followup survey asks to confirm that the old season of docs proposal and outcome is still available. While technically true, the proposal is not linked anywhere. this Is to fix that