### PR TITLE
Small fix to GSoC proposal title

### DIFF
--- a/_gsocproposals/2024/proposal_GangaAIassistant.md
+++ b/_gsocproposals/2024/proposal_GangaAIassistant.md
@@ -1,6 +1,6 @@
 ---
 project: Ganga
-title: Incorporate a Large Language Model to assist users
+title: Ganga - Incorporate a Large Language Model to assist users
 layout: gsoc_proposal
 year: 2024
 difficulty: medium


### PR DESCRIPTION
The title is used in the full list of proposals https://hepsoftwarefoundation.org/gsoc/2024/summary.html, which misses the context of the project, so the project name needs to be repeated here.

This is just an intermediate fix to make the list presentable, we should very likely prefix the project name in the template for this list.