### PR TITLE
gsoc: Prepend project name in full list of proposals

### DIFF
--- a/_gsocproposals/2024/proposal_CVMFS_Buildcache.md
+++ b/_gsocproposals/2024/proposal_CVMFS_Buildcache.md
@@ -1,5 +1,5 @@
 ---
-title: CernVM-FS - Buildcache of vendored dependencies
+title: Buildcache of vendored dependencies
 layout: gsoc_proposal
 project: CernVM-FS
 year: 2024

--- a/_gsocproposals/2024/proposal_CVMFS_FUSE_features.md
+++ b/_gsocproposals/2024/proposal_CVMFS_FUSE_features.md
@@ -1,5 +1,5 @@
 ---
-title: CernVM-FS - Benchmarking of new FUSE features
+title: Benchmarking of new FUSE features
 layout: gsoc_proposal
 project: CernVM-FS
 year: 2024

--- a/_gsocproposals/2024/proposal_GangaAIassistant.md
+++ b/_gsocproposals/2024/proposal_GangaAIassistant.md
@@ -1,6 +1,6 @@
 ---
 project: Ganga
-title: Ganga - Incorporate a Large Language Model to assist users
+title: Incorporate a Large Language Model to assist users
 layout: gsoc_proposal
 year: 2024
 difficulty: medium

--- a/gsoc/2024/summary.md
+++ b/gsoc/2024/summary.md
@@ -9,11 +9,11 @@ year: 2024
 ## Full List of Proposals
 
 {:.table .table-hover .table-striped}
-{% assign sorted_proposals = site.gsocproposals | sort: 'title' %}
+{% assign sorted_proposals = site.gsocproposals | sort: "url" %}
 {% for proposal in sorted_proposals %}{% capture u_proposal_org %}{{ organization | upcase }}{% endcapture %}
 {%- assign strings = proposal.url | split: '/' -%}
 {%- assign proposal_year = strings[2] | plus: 0 -%}
 {%- if proposal_year == page.year %}
-| [ {{ proposal.title }} ]( {{ proposal.url }} ) |
+| [**{{ proposal.project }}:** {{ proposal.title }} ]( {{ proposal.url }} ) |
 {%- endif -%}
 {% endfor %}


### PR DESCRIPTION
The metadata format of the proposals

```
---
project: Ganga
title: Incorporate a Large Language Model to assist users
layout: gsoc_proposal
year: 2024
...
```

nudges authors to write the title in context of the project. In the full list of project proposals (which we have to submit to gsoc), this context is lost, so the project name has to be repeated in the title for it to make sense, in many cases.

I propose instead to fix the list, prefixing the project name there.

This would mess with the order of the list though, so I update the sorting as well. I couldn't get `sort: 'project'` to work (jekyll complains about not being able to do a comparison), but `sort: 'url'` is a nice proxy for project name + title.

Preview:
![image](https://github.com/HSF/hsf.github.io/assets/5057884/ed0bb973-4523-4cd8-98e3-4e99c6be6c81)

