### PR TITLE
gsoc: fix typo and whitespace in Key4hep project description

### DIFF
--- a/_gsocprojects/2024/project_Key4hep.md
+++ b/_gsocprojects/2024/project_Key4hep.md
@@ -4,12 +4,7 @@ project: Key4hep
 layout: default
 logo:
 description: |
-  The [Key4hep](https://cern.ch/key4hep/) project builds novel HEP stack
-  focused on future collider concepts. It's main components are event processing
-  framework --- [Gaudi](https://cern.ch/gaudi), event data
-  model --- [EDM4hep](https://cern.ch/edm4hep), detector geometry
-  description --- [DD4hep](https://cern.ch/dd4hep), and distribution
-  platform --- [Spack](https://spack.io/)
+  The [Key4hep](https://cern.ch/key4hep/) project builds an experiment-independent, complete HEP stack focused on future collider concepts. Its key ingredients are event processing framework --- [Gaudi](https://cern.ch/gaudi), event data model --- [EDM4hep](https://cern.ch/edm4hep), detector geometry description --- [DD4hep](https://cern.ch/dd4hep), and distribution platform --- [Spack](https://spack.io/).
 ---
 
 {% include gsoc_project.ext %}


### PR DESCRIPTION
Multiline descriptions lead to missing whitespace between words