### PR TITLE
[gsoc24] remove repetition of Cppyy project name

### DIFF
--- a/_gsocproposals/2024/proposal_Cppyy-STL-Eigen-support.md
+++ b/_gsocproposals/2024/proposal_Cppyy-STL-Eigen-support.md
@@ -1,5 +1,5 @@
 ---
-title: Cppyy STL/Eigen - Automatic conversion and plugins for Python based ML-backends 
+title: STL/Eigen - Automatic conversion and plugins for Python based ML-backends 
 layout: gsoc_proposal
 project: Cppyy
 year: 2024


### PR DESCRIPTION
This PR updates the title of a Cppyy proposal to prevent repetition since the project name is now prepended to the title