### PR TITLE
fix: update convener name

### DIFF
--- a/_workinggroups/recotrigger.md
+++ b/_workinggroups/recotrigger.md
@@ -27,10 +27,10 @@ of profiling and quality assurance toolkits.
 Current WG conveners:
 - Christina Agapopoulou (LHCb, CERN)
 - Claire Antel (ATLAS/FASER, Uni Geneva)
-- Giulia Casarosa (Belle II, Università di Pisa)
+- Joe Osborn (sPHENIX/ePIC, Brookhaven National Laboratory)
 
 
-[Contact the group conveners](mailto:christina.agapopoulou@cern.ch,claire.antel@cern.ch,giulia.casarosa@pi.infn.it) by email. <!-- markdown-link-check-disable-line -->
+[Contact the group conveners](mailto:christina.agapopoulou@cern.ch,claire.antel@cern.ch,josborn1@bnl.gov) by email. <!-- markdown-link-check-disable-line -->
 
 Everyone is welcome to participate and contribute on the forum and to the ongoing meetings. For more information, contact us or
 follow our mailing list on google groups [hsf-recotrigger](https://groups.google.com/forum/#!forum/hsf-recotrigger).
@@ -49,7 +49,7 @@ follow our mailing list on google groups [hsf-recotrigger](https://groups.google
 [Mandate and link to other HSF working groups]({{ site.baseurl }}/organization/working-group-mandates.html).
 
 ## Former Conveners
-
+- Giulia Casarosa (Belle II, Universita di Pisa), 2022-2023
 - Andreas Salzburger (ATLAS, CERN), 2021-2022
 - Jin Huang (sPHENIX/EIC, BNL), 2021-2022
 - Dorothea vom Bruch (LHCb, CPPM), 2021-2022


### PR DESCRIPTION
This PR updates the reco/trig software page to reflect the new convenor roles for the year 2024.