### PR TITLE
gsoc: general fix for whitespaces in project/org summaries

### DIFF
--- a/_includes/gsoc_organization_list.ext
+++ b/_includes/gsoc_organization_list.ext
@@ -12,7 +12,10 @@ This liquid template produces the list of organizations for the year passed as a
   {% assign year_position = url_tokens.size | minus: 2 %}
   {% assign org_year = url_tokens[year_position] %}
   {% capture org_summary %}{%if org.summary %}{{ org.summary }}{%else%}{{ org.description}}{%endif%}{% endcapture %}
-  {% assign org_summary = org_summary | strip_newlines | markdownify %}
+{% comment %}
+Just stripping the newlines out of the description often results in incorrect whitespace - explicitly replace with whitespace instead.
+{% endcomment %}
+  {% assign org_summary = org_summary | newline_to_br | strip_newlines | replace: '<br />', ' '  | strip_html | strip | markdownify %}
   {% if org_year == include.year %}
   <tr>
     {% if org.logo %}

--- a/_includes/gsoc_project_list.ext
+++ b/_includes/gsoc_project_list.ext
@@ -12,7 +12,10 @@ This liquid template produces the list of projects for the year passed as a para
   {% assign year_position = url_tokens.size | minus: 2 %}
   {% assign project_year = url_tokens[year_position] %}
   {% capture project_summary %}{%if project.summary %}{{ project.summary }}{%else%}{{ project.description}}{%endif%}{% endcapture %}
-  {% assign project_summary = project_summary | strip_newlines | markdownify %}
+{% comment %}
+Just stripping the newlines out of the description often results in incorrect whitespace - explicitly replace with whitespace instead.
+{% endcomment %}
+  {% assign project_summary = project_summary | newline_to_br | strip_newlines | replace: '<br />', ' '  | strip_html | strip | markdownify %}
   {% if project_year == include.year %}
   <tr>
     {% if project.logo %}


### PR DESCRIPTION
Due to the project/org descriptions being multiline yaml strings that had their newlines stripped, it's easy to mess up the whitespaces. This should bring an end to these woes, even if it makes the template a bit more roundabout (implementation from https://stackoverflow.com/questions/45147948/how-to-strip-newlines-in-jekyll). In my test, existing descriptions look OK, the whitespace in the Ganga one has been fixed, and it should no longer matter if you put newlines in `description: |`