### PR TITLE
fix: conveners list on HSF Training

### DIFF
--- a/_workinggroups/training.md
+++ b/_workinggroups/training.md
@@ -141,7 +141,7 @@ We are always looking for volunteers from the community to help us with our trai
 {% endif %}
 ## Conveners
 
-{% assign persons = "Alexander Moreno Briceño, Valeriia Lukashenko, Jim Pivarski, Holly Szumila" | split: ", " %}
+{% assign persons = "Alexander Moreno Briceño, Lera Lukashenko, Jim Pivarski, Holly Szumila-Vance" | split: ", " %}
 {% include list_of_selected_profiles.html %}
 
 The conveners can be [reached by email](mailto:alexander.moreno@uan.edu.co,valeriia.lukashenko@cern.ch,pivarski@princeton.edu,hszumila@jlab.org). <!-- markdown-link-check-disable-line -->


### PR DESCRIPTION
I was about to give up on #1512 and replace the fancy list with a simple bulleted list, but then I noticed that Lera's and Holly's names were not exactly the same as the `title` attribute in their profiles. So I'll try that first, and if it renders correctly, #1512 is fixed. If not, we use a bulleted list.