### PR TITLE
fix: Project category for ROOT/TMVA

### DIFF
--- a/_gsocproposals/2024/proposal_ROOT-TMVA-SOFIE.md
+++ b/_gsocproposals/2024/proposal_ROOT-TMVA-SOFIE.md
@@ -1,7 +1,7 @@
 ---
 title: SOFIE Developments - Inference Code Generation for Deep Learning models
 layout: gsoc_proposal
-project: ROOT/TMVA
+project: ROOT
 difficulty: medium
 duration: 350
 mentor_avail: May-September


### PR DESCRIPTION
This PR makes a minor correction in fixing the project category name for the TMVA SOFIE project under ROOT.