### PR TITLE
Redirect to new training center

### DIFF
--- a/_training/center.md
+++ b/_training/center.md
@@ -3,6 +3,8 @@ title: HSF Software Training Center
 layout: plain
 redirect_from:
 - /training/curriculum
+redirect_to:
+- https://hsf-training.org
 ---
 
 <script defer data-domain="hepsoftwarefoundation.org" src="https://views.scientific-python.org/js/script.js"></script>


### PR DESCRIPTION
Now that the new training center is live (https://hsf-training.org), we should redirect the old page to the new domain. For now, I didn't remove anything in case we need to revert back if there are issues with the new one, but it would be good to have the new one fully deployed and get some feedback on what could be improved.