### PR TITLE
Replace Coordination Team with Steering Group

### DIFF
--- a/_includes/about.ext
+++ b/_includes/about.ext
@@ -6,6 +6,6 @@ Informing the community of news across the HSF activity areas. <br>
 <a href="{{ '/organization/about.html' | relative_url }}">Learn more here</a>.
 </p><p>
 For more information on the HEP Software Foundation see the <a href="http://hepsoftwarefoundation.org">HSF website</a> or
-contact the <a href="mailto:hsf-coordination@googlegroups.com">startup team</a>.
+contact the <a href="mailto:hsf-steering@googlegroups.com">startup team</a>.
     </p>
   </div>

--- a/_includes/sidebar.ext
+++ b/_includes/sidebar.ext
@@ -3,7 +3,7 @@
     <h4>About the HSF</h4>
     <p>
 For more information on the HEP Software Foundation see the <a href="{{ '/organization/goals.html' | relative_url }}">goals</a> page or
-contact the <a href="mailto:hsf-coordination@googlegroups.com">startup team</a>.
+contact the <a href="mailto:hsf-steering@googlegroups.com">Steering Group</a>.
     </p>
   </div>
   <div class="sidebar-module sidebar-module-inset">

--- a/_meetings/roundtable.md
+++ b/_meetings/roundtable.md
@@ -22,9 +22,8 @@ with high-energy physics.
 * [Roundtable Meetings in 2021](https://indico.jlab.org/event/420/)
 * [Roundtable Meetings in 2020](https://indico.jlab.org/event/356/)
 
-If you would like to suggest a topic for the Roundtable, please contact the [HSF
-Coordination](mailto:hsf-coordination@googlegroups.com). The current HSF
-representative is [Graeme Stewart](mailto:graeme.andrew.stewart@cern.ch).
+If you would like to suggest a topic for the Roundtable, please contact the [HSF Steering Group](mailto:hsf-steering@googlegroups.com). The current HSF
+representative is [Andrea Valassi](mailto:Andrea.Valassi@cern.ch).
 
 <p align=center>
 <img src="{{ '/images/JLab_logo.png' | relative_url }}"

--- a/_meetings/software-forum.md
+++ b/_meetings/software-forum.md
@@ -15,4 +15,4 @@ areas or meeting series.
 
 The meeting schedule is in [Indico](https://indico.cern.ch/category/10392/){:_target="HSF_Software_Forum"}.
 
-[Suggestions](mailto:hsf-coordination@googlegroups.com) for any future meeting topics are always very welcome.
+[Suggestions](mailto:hsf-steering@googlegroups.com) for any future meeting topics are always very welcome.

--- a/future-events.md
+++ b/future-events.md
@@ -7,4 +7,4 @@ layout: plain
 
 - To add this calendar to your own setup, use this [ical link](https://calendar.google.com/calendar/ical/e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com/public/basic.ics). You can also view the [Standalone calendar page](https://calendar.google.com/calendar/embed?src=e4v33e1a1drbncdle1n03ahpcs%40group.calendar.google.com&ctz=Europe/Amsterdam).
 
-- If you would like an event added to the calendar, please contact the [HSF Coordination Group](mailto:hsf-coordination@googlegroups.com) (we can grant [editing rights]({{ site.baseurl }}/calendar.html) where appropriate).
+- If you would like an event added to the calendar, please contact the [HSF Steering Group](mailto:hsf-steering@googlegroups.com) (we can grant [editing rights]({{ site.baseurl }}/calendar.html) where appropriate).

--- a/get_involved.md
+++ b/get_involved.md
@@ -10,7 +10,7 @@ Our goal is to make every effort going on as transparent and open as possible.
 Our official communication channel is the 
 [hsf-forum](https://groups.google.com/forum/#!forum/hsf-forum). If you want to contact
 a smaller group of HSF advocates you can get in touch with the
-[HSF Coordination Team]({{ site.baseurl }}/organization/team.html).
+[HSF Steering Group]({{ site.baseurl }}/organization/team.html).
 
 See the [dedicated page]({{ site.baseurl }}/forums.html) about HSF discussions forums for
 information about how to register and the
@@ -25,7 +25,7 @@ by joining the HSF with your software project:
   *  Participation in HSF [working groups]({{ site.baseurl }}/what_are_WGs.html) and [activity areas]({{ site.baseurl }}/what_are_activities.html)
   *  Participation in [HSF events and meetings]({{ site.baseurl }}/future-events.html)
   *  Taking advantage of the HSF by identifying your [software project]({{ site.baseurl }}/projects.html) with us
-  *  Giving input to the [HSF Coordination Team]({{ site.baseurl }}/organization/team.html)
+  *  Giving input to the [HSF Steering Group]({{ site.baseurl }}/organization/team.html)
   *  Contributing to this website
 
 ## Meetings, Agendas and Video-Conferences Access
@@ -38,12 +38,12 @@ to many of its services, if you do not have a full CERN account.
 
 The [Zoom](https://videoconference.web.cern.ch/t/about-the-zoom-cern-service/24) video conferencing system is used for almost all HSF meetings and anyone can participate in the meetings from any internet-connected location. Connection information for each specific Zoom meeting is on the corresponding Indico meeting agenda page.
 
-## Giving input to the HSF Coordination Team
+## Giving input to the HSF Steering Group
 
 If you are not certain about raising an issue in the
 [forums]({{ site.baseurl }}/forums.html) and mailing lists, or if you are afraid that this is not the
 right place for it, feel free to contact the
-[HSF coordination team](mailto:hsf-coordination@googlegroups.com) directly.
+[HSF Steering Group](mailto:hsf-steering@googlegroups.com) directly.
 
 ## Contributing to this website
 

--- a/howto-website.md
+++ b/howto-website.md
@@ -6,7 +6,7 @@ layout: default
 
 ## About the HSF website
 
-This site is maintained by the HSF GitHub [contributors](https://github.com/orgs/HSF/people). If you're interested to become one contact the [HSF coordination team]({{ site.baseurl }}/organization/team.html) or any team member. It was set up by Torre Wenaus and Benedikt Hegner.
+This site is maintained by the HSF GitHub [contributors](https://github.com/orgs/HSF/people). If you're interested to become one contact the [HSF Steering Group]({{ site.baseurl }}/organization/team.html) or any team member. It was set up by Torre Wenaus and Benedikt Hegner.
 
 ## Implementation
 

--- a/inventory/inventory.md
+++ b/inventory/inventory.md
@@ -10,4 +10,4 @@ The HSF helps to compile an inventory of community software projects.
 If you know of a particularly useful or critical software package then
 please let us know about it, by contacting the appropriate
 [Working Group Convenors]({{ site.baseurl }}/what_are_WGs.html) or
-[HSF Coordinators](mailto:hsf-coordination@googlegroups.com).
+[HSF Steering Group](mailto:hsf-steering@googlegroups.com).

--- a/organization/goals.md
+++ b/organization/goals.md
@@ -25,6 +25,6 @@ to set priorities and goals for the work. It can also facilitate wider
 connections; while the HSF is a HEP community effort, it should be open
 enough to form the basis for collaboration with other sciences.
 
-The [HSF Coordination Team]({{ site.baseurl }}/organization/team.html) help run the
+The [HSF Steering Group]({{ site.baseurl }}/organization/team.html) help run the
 organisation on a day to day basis.
 Please feel free to ask us any questions you have.

--- a/organization/hsf-letters.md
+++ b/organization/hsf-letters.md
@@ -28,7 +28,7 @@ project are well aligned with the [Community White Paper]({{ site.baseurl
 }}/organization/cwp.html) and other similar documents. To ask us for this
 please:
 
-- Send a request to [HSF Coordination](mailto:hsf-coordination@googlegroups.com)
+- Send a request to the [HSF Steering Group](mailto:hsf-steering@googlegroups.com)
 - Include an outline of your project's goals and indicate where you
   believe that the HSF can usefully cooperate and work with you
   - We strongly encourage you do discuss with the working group conveners of
@@ -45,7 +45,7 @@ call where there is one application from the HEP community. Projects should be
 able to demonstrate specific aims to tackle the challenges set out in the
 [Community White Paper]({{ site.baseurl }}/organization/cwp.html).
 
-- Send a request to [HSF Coordination](mailto:hsf-coordination@googlegroups.com)
+- Send a request to [HSF Steering Group](mailto:hsf-steering@googlegroups.com)
 - Include an outline of your project's goals and indicate in what way
   this helps the high-energy physics community to meet the software challenges
   of the future
@@ -56,7 +56,7 @@ able to demonstrate specific aims to tackle the challenges set out in the
 
 ## Procedure
 
-In both cases the HSF Coordination group and the HSF Working Group Conveners
+In both cases the HSF Steering Group and the HSF Working Group Conveners
 will discuss the request and, if approved, circulate a draft letter and the
 project outline **to the whole of the HSF community** for any comments. We will
 then approve the request in an HSF Coordination meeting (or, exceptionally, just

--- a/organization/minutes.md
+++ b/organization/minutes.md
@@ -7,7 +7,7 @@ layout: default
 
 ## Meeting Minutes
 
-The coordination team runs a regular HSF meeting (nominally, and usually, weekly) which is open to all.
+The [HSF Steering Group]({{ site.baseurl }}/organization/team.html) runs a regular HSF meeting (nominally, and usually, weekly) which is open to all.
 Meeting announcements and minutes are posted to the HSF forum Google group.
 Activity groups also hold their own meetings, for which minutes are usually posted here.
 

--- a/organization/youtube.md
+++ b/organization/youtube.md
@@ -45,4 +45,4 @@ The current HSF Owners are:
 * Eduardo Rodrigues <eduardo.rodrigues@cern.ch>
 
 If you aren't able to contact an owner, please ask the 
-[HSF Coordination Team]({{ site.baseurl }}/organization/team.html) for advice.
+[HSF Steering Group]({{ site.baseurl }}/organization/team.html) for advice.

--- a/projects.md
+++ b/projects.md
@@ -6,7 +6,7 @@ layout: default
 
 # HSF Projects
 
-HSF seeks to serve new and emerging common projects through a project incubator activity. Templates to guide and aid new projects are being established. If you'd like your project to be involved just let us know. Talk to any member of the coordination team or email hsf-coordination@googlegroups.com.
+HSF seeks to serve new and emerging common projects through a project incubator activity. Templates to guide and aid new projects are being established. If you'd like your project to be involved just let us know. Talk to any member of the HSF Steering Group or [email](mailto:hsf-steering@googlegroups.com).
 
 The incubator idea is close to the one of the Apache Software Foundation. Brian Van Klaveren who gave the exceptional ASF talk at the SLAC workshop provides [this link](http://www.apache.org/foundation/how-it-works.html#incubator) describing how ASF Incubator projects work.
 

--- a/services.md
+++ b/services.md
@@ -16,7 +16,7 @@ Message sent to the HSF forum on March 26 2015
 
 <div class="rteindent1" style="color: rgb(34, 34, 34); font-family: arial, sans-serif; font-size: 12.8000001907349px; line-height: normal;"> </div>
 
-<div class="rteindent1" style="color: rgb(34, 34, 34); font-family: arial, sans-serif; font-size: 12.8000001907349px; line-height: normal;">We invite people to get in touch with us who are interested to have their projects participate as an early adopter and guinea pig. Contact the startup team at <a href="mailto:hsf-coordination@googlegroups.com" style="color: rgb(17, 85, 204);" target="_blank">hsf-coordination@googlegroups.com</a>. </div>
+<div class="rteindent1" style="color: rgb(34, 34, 34); font-family: arial, sans-serif; font-size: 12.8000001907349px; line-height: normal;">We invite people to get in touch with us who are interested to have their projects participate as an early adopter and guinea pig. Contact the startup team at <a href="mailto:hsf-steering@googlegroups.com" style="color: rgb(17, 85, 204);" target="_blank">hsf-steering@googlegroups.com</a>. </div>
 
 ## TechForum interest list
 

--- a/what_are_WGs.md
+++ b/what_are_WGs.md
@@ -25,7 +25,7 @@ experiments.
 If you want to form a working group, or want to put some community-wide
 activity under the umbrella of the HSF,
 just contact the
-[HSF coordination team](mailto:hsf-coordination@googlegroups.com).
+[HSF Steering Group](mailto:hsf-steering@googlegroups.com).
 
 Working Groups are added to the website of the HSF, with 
 description and contact information, and their own
@@ -75,7 +75,7 @@ Our working group conveners should usually dedicate between 5% and 10% of their
 time to running the working group. More than 10% is great, but we recognise
 that people are busy with many other tasks. Less than 5% and the working group
 can fall into an inactive state. Conveners should meet at least once a month to
-plan. The HSF Coordination Group is always happy to attend to give feedback
+plan. The HSF Steering Group is always happy to attend to give feedback
 and suggestions.
 
 At least one of the working group conveners should attend the bi-weekly

--- a/what_are_activities.md
+++ b/what_are_activities.md
@@ -17,7 +17,7 @@ and any relevant and reasonable activity for HEP can spawn
 an interest group. If you want to put some community-wide
 activity under the umbrella of the HSF as an activity areas or interest group
 just contact the
-[HSF coordination team](mailto:hsf-coordination@googlegroups.com).
+[HSF Steering Group](mailto:hsf-steering@googlegroups.com).
 
 Activity areas are added to the website of the HSF, with 
 description and contact information and will have a dedicated mailing list


### PR DESCRIPTION
Both text and email links are updated for all active pages. Note that historical references to HSF Coordination (in minutes) were NOT changed.