### PR TITLE
Fixed link checker

### DIFF
--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -1,6 +1,6 @@
 name: link_checker
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   check_new_links:

--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Ruby Install
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.x
+          ruby-version: 3.2.5
       - name: Setup Jekyll
         run: |
           gem update --system --no-document

--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -13,13 +13,8 @@ jobs:
       - name: Ruby Install
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.5
-      - name: Setup Jekyll
-        run: |
-          gem update --system --no-document
-          gem update bundler --no-document
-          gem install jekyll bundler
-          bundle install
+          ruby-version: '3.2'
+          bundler-cache: true
       - name: Jekyll Build
         run: bundler exec jekyll build
       - name: Check Links

--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -1,21 +1,28 @@
-name: link_checker
+name: Check Markdown links
 
 on: [push, pull_request]
 
 jobs:
-  check_new_links:
-    name: link_checker
+  markdown-link-check:
     runs-on: ubuntu-latest
-    container: jekyll/jekyll
+    strategy:
+      fail-fast: false
     steps:
-      - name: checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
-
-      - name: jekyll build
+      - name: Ruby Install
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.x
+      - name: Setup Jekyll
         run: |
-          bundler exec jekyll build
-
-      - name: actions link checker
+          gem update --system --no-document
+          gem update bundler --no-document
+          gem install jekyll bundler
+          bundle install
+      - name: Jekyll Build
+        run: bundler exec jekyll build
+      - name: Check Links
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           config-file: '.github/config/mdcheck.json'

--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -1,12 +1,12 @@
 name: link_checker
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   check_new_links:
     name: link_checker
     runs-on: ubuntu-latest
-    container: hepsoftwarefoundation/hsf-jekyll
+    container: jekyll/jekyll
     steps:
       - name: checkout repository
         uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,3 @@
 source "https://rubygems.org"
 
-gem 'jekyll-feed'
-gem "github-pages", ">= 150"
-gem "html-proofer"
-
-# Suggested by Jekyll
-gem 'wdm', '>= 0.1.0' if Gem.win_platform?
-
-# Required on Windows
-gem 'tzinfo-data'  if Gem.win_platform?
-
-# Needed for Ruby > 3.1? due to changed dependencies
-gem 'webrick'
+gem 'github-pages', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-name: HEP Software Foundation Newsletter
-description: News from the HEP Software Foundation
+title: HEP Software Foundation
+description: HEP Software Foundation Website
 url: http://www.hepsoftwarefoundation.org
 excerpt_separator: <!--more-->
 timezone: Europe/Paris

--- a/organization/team.md
+++ b/organization/team.md
@@ -3,7 +3,12 @@ title: "HSF Steering Group"
 layout: plain
 ---
 
-Testing: here is a deliberate [bad link](https://i.do.not.exist/void.html).
+Testing:
+
+- here is a deliberate [bad link](https://i.do.not.exist/void.html).
+- this is a [good link](https://home.cern).
+- this is a [good internal link]({{ site.baseurl }}/what_are_WGs.html)
+- this is a [bad internal link]({{ site.baseurl }}/verybogus.html)
 
 The HEP Software Foundation Steering Group (SG) is a group of motivated individuals who take responsibility for promoting, guiding and monitoring the HSF’s activities in all areas. They have the role of preserving the HSF’s knowledge and engagement with the community over multiple years and over changes of working group conveners.
 

--- a/organization/team.md
+++ b/organization/team.md
@@ -3,13 +3,6 @@ title: "HSF Steering Group"
 layout: plain
 ---
 
-Testing:
-
-- here is a deliberate [bad link](https://i.do.not.exist/void.html).
-- this is a [good link](https://home.cern).
-- this is a [good internal link]({{ site.baseurl }}/what_are_WGs.html)
-- this is a [bad internal link]({{ site.baseurl }}/verybogus.html)
-
 The HEP Software Foundation Steering Group (SG) is a group of motivated individuals who take responsibility for promoting, guiding and monitoring the HSF’s activities in all areas. They have the role of preserving the HSF’s knowledge and engagement with the community over multiple years and over changes of working group conveners.
 
 The SG takes responsibility for deciding on which working groups and activities that the HSF will engage in, with a view to making the HSF’s activities as beneficial for the HEP community as possible, whilst also respecting and nurturing the HSF’s “bottom-up” philosophy. Input from the Advisory Group is addressed. The SG will meet regularly, once a quarter.

--- a/organization/team.md
+++ b/organization/team.md
@@ -3,6 +3,8 @@ title: "HSF Steering Group"
 layout: plain
 ---
 
+Testing: here is a deliberate [bad link](https://i.do.not.exist/void.html).
+
 The HEP Software Foundation Steering Group (SG) is a group of motivated individuals who take responsibility for promoting, guiding and monitoring the HSF’s activities in all areas. They have the role of preserving the HSF’s knowledge and engagement with the community over multiple years and over changes of working group conveners.
 
 The SG takes responsibility for deciding on which working groups and activities that the HSF will engage in, with a view to making the HSF’s activities as beneficial for the HEP community as possible, whilst also respecting and nurturing the HSF’s “bottom-up” philosophy. Input from the Advisory Group is addressed. The SG will meet regularly, once a quarter.


### PR DESCRIPTION
The link checker is fixed! I have updated it to *not* use a container, but to instead use the `ruby/setup` action running on the default `ubuntu-latest` GitHub platform. This frees us from the obligation to maintain our own container and keep it up to date with Jekyll and ruby versions.

The link checker configuration itself is unchanged, but has been tested by deliberately injecting some bad links on which it properly failed.

Closes #1559.
