### PR TITLE
Update documentation about editing website

### DIFF
--- a/howto-website.md
+++ b/howto-website.md
@@ -6,7 +6,7 @@ layout: default
 
 ## About the HSF website
 
-This site is maintained by the HSF GitHub [contributors](https://github.com/orgs/HSF/people). If you're interested to become one contact the [HSF Steering Group]({{ site.baseurl }}/organization/team.html) or any team member. It was set up by Torre Wenaus and Benedikt Hegner.
+This site is maintained by the HSF GitHub [contributors](https://github.com/orgs/HSF/people). If you're interested to become one, contact the [HSF Steering Group]({{ site.baseurl }}/organization/team.html) or any team member. It was set up by Torre Wenaus and Benedikt Hegner.
 
 ## Implementation
 
@@ -29,26 +29,21 @@ The website uses the main branch of the [hsf.github.io](https://github.com/HSF/h
 If you are not familiar with GitHub and Git, you can read our [survival kit]({{ site.baseurl }}/github-beginners.html)!
 
 ### General structure of website content files
+
 All Markdown files of this site start with a section surrounded by `---`. This
 so-called *front-matter* contains metadata about the content. Such metadata are,
 e.g., the author of the document or the title of the document.
 
 In the *front-matter* (but not in the text itself), you need to replace any `&` characters (which has a special meaning in HTML) by `&amp;`. This is particularly important for the `title` attribute.
 
-### Adding content from collaborative tools
+### Adding content from collaborative tools (live notes)
 
-#### CodiMD
+#### Markdown file
 
-The recommended way to host a collaborative note book, e.g. for taking meeting minutes
-is to use [CodiMD](https://hackmd.io/c/codimd-documentation/%2Fs%2Fcodimd-documentation), which is
-a collaborative ediitng tool utilising Markdown directly. This makes it trivial to move
-the content into the HSF website for archiving.
+The recommended way to host a collaborative note book, e.g. for taking meeting minutes (live notes),
+is to use a collaborative editing tool utilising Markdown directly.  This makes it trivial to move the content into the HSF website for archiving.
 
-CERN has its own [CodiMD instance](https://codimd.web.cern.ch/), but currently this only
-works if every contributor has a full CERN account (EduGain authentication is proposed,
-but it doesn't work yet AFAWU). An alternative is the [demo CodiMD service](https://demo.codimd.org/),
-but be aware that there is no long term guarantee for content here, so move it to the 
-website after your meeting.
+[CodiMD](https://hackmd.io/c/codimd-documentation/%2Fs%2Fcodimd-documentation) is the suggested choice as it has been designed for collaboraitve editing of Markdown files. Unfortunately, the [Hackmd](https://hackmd.io) free service is now restricted to 4 editors. Another possibility, if you have a CERN account, is to use CERNBox which makes CodiMD available to edit Markdown files: you can then define a public link to the document (similar to Google Docs public links) to allow those without a CERN account to edit the file.
 
 We find that *recycling* the same document for a series of meetings is extremely useful
 as the *live notes* link can be copied and cloned from one meeting to the next.
@@ -59,6 +54,12 @@ Google Docs can also be used for shared notebooks, but in this case there is a n
 the document to Markdown before it can be added to the website. This is less convenient, but
 we have [documentation]({{ site.baseurl }}/jekyll-beginners.html) on how to do it.
 
+
+### Adding coordination meeting minutes
+
+HSF Coordination minutes are produced using the live notes approach described above. The content of the live notes are preformatted to be suitable for direct injection into Jekyll. The minutes file must be placed into Jekyll `organization/_posts` directory.
+
+The only edit required is the replacement of the *front-matter* section by the one present in the previous meeting minutes in Jekyll, updating the title (meeting number and date).
 
 ### Adding a working group or activity
 

--- a/organization/running-meetings.md
+++ b/organization/running-meetings.md
@@ -11,16 +11,16 @@ Then, here is a short checklist for running the meeting:
 
 1. **Announce the meeting**: Indico should be setup to send reminders about the meetings 2 days and 2 hours in advance. These go to HSF Core Coordination and the HSF working group conveners, so you don't usually need to do this manually.
     - However, if specific input is needed you might want to send a targeted email a suitable time in advance.
-2. **Prepare the minutes**: The meeting is minuted in the [live notes](https://demo.hedgedoc.org/COseSwVnQRuYOAWpHC756Q?view) document. A few days before the meeting (usually on Monday when the weekly meetings email is sent) clean up this document.
+2. **Prepare the minutes**: The meeting is minuted in the [live notes](https://hepsoftwarefoundation.org/howto-website.html) document. A few days before the meeting (usually on Monday when the weekly meetings email is sent) clean up this document.
     1. Check that the previous meeting's minutes were published on the [website](https://hepsoftwarefoundation.org/organization/minutes.html). If not, see if there is a [pull request](https://github.com/HSF/hsf.github.io/pulls) and remind people to edit/accept that.
         - In the rare case where the minutes from the previous meeting have not been handled, please save a copy of the previous minutes before you start the clean up.
     2. Clean up the different sections from the last meeting (there are a few "standing items" as reminders that get left from meeting to meeting).
     3. Pre-populate the minutes with news and any other items of working group information or AOB that you are aware of.
 3. **Chair the meeting**: Generally this is going through the list of news items, working group reports and AOBs. Ensure you call for comments/questions. Usually people know to pre-populate the minutes, but discussion points and comments need to be recorded. Encourage people to write these directly, but take them yourself if necessary.
     - To take proper attendance (not everyone remembers to write their name), it's a good idea to just screenshot the Zoom participants window.
-4. **Make a PR with the minutes**: Following the usual procedures for adding content to the HSF website (documented [here](https://hepsoftwarefoundation.org/howto-website.html) and [here](https://hepsoftwarefoundation.org/howto-website.html)), make a GitHub PR to the [HSF website repository](https://github.com/HSF/hsf.github.io). 
+4. **Make a PR with the minutes**: Following the usual procedures for adding content to the HSF website (documented [here](https://hepsoftwarefoundation.org/howto-website.html)), make a GitHub PR to the [HSF website repository](https://github.com/HSF/hsf.github.io). 
     - Note that all of the [previous minutes](https://github.com/HSF/hsf.github.io/tree/main/organization/_posts) are nice templates for the small number of changes between CodiMD and the GitHub Markdown for the website.
-        - In particular, we don't publish standing reminders or *NTR* sections, just delete these.
+        - **In particular, we don't publish standing reminders or *NTR* sections, just delete these.**
     - Ask one of the other participants to review the PR - it avoids a lot of mistakes, typos and omissions when someone else takes a look.
     - If you don't have permission to do any of those steps, ask on the <hsf-core-coordination@googlegroups.com> list (send your GitHub ID) and someone will set this up for you.
 


### PR DESCRIPTION
- CodiMD section updated to reflect that the Hackmd.io service is not really an option anymore and suggest CERNBox for those who can use it
- repetition removed in running_meetings document