### PR TITLE
fix codespell

### DIFF
--- a/codespell.txt
+++ b/codespell.txt
@@ -19,3 +19,4 @@ caf
 gage
 gauge
 re-use
+extint


### PR DESCRIPTION
Add github username of gsoc contributor to whitelist. I would have thought that there's another way to avoid codespell to trigger as this only appears  in URLs but haven't found anything. This introduces the risk of future misspellings of "extinct", but I'm  just going to hope that nothing goes extinct and the risk remains small :)