### PR TITLE
Web how-to improvements

### DIFF
--- a/howto-website.md
+++ b/howto-website.md
@@ -57,9 +57,7 @@ we have [documentation]({{ site.baseurl }}/jekyll-beginners.html) on how to do i
 
 ### Adding coordination meeting minutes
 
-HSF Coordination minutes are produced using the live notes approach described above. The content of the live notes are preformatted to be suitable for direct injection into Jekyll. The minutes file must be placed into Jekyll `organization/_posts` directory.
-
-The only edit required is the replacement of the *front-matter* section by the one present in the previous meeting minutes in Jekyll, updating the title (meeting number and date).
+HSF Coordination minutes are produced using the live notes approach described above. The content of the live notes are preformatted to be suitable for direct injection into Jekyll, after minimal edits described in the [running-meetings]({{ site.baseurl }}/organization/running-meetings.html) page. The minutes file must be placed into Jekyll `organization/_posts` directory.
 
 ### Adding a working group or activity
 

--- a/organization/running-meetings.md
+++ b/organization/running-meetings.md
@@ -13,16 +13,17 @@ Then, here is a short checklist for running the meeting:
 
 1. **Announce the meeting**: Indico should be setup to send reminders about the meetings 2 days and 2 hours in advance. These go to HSF Steering Group and Activity Area conveners, so you don't usually need to do this manually.
     - However, if specific input is needed you might want to send a targeted email a suitable time in advance.
-2. **Prepare the minutes**: The meeting is minuted in the [live notes](https://hepsoftwarefoundation.org/howto-website.html) document. A few days before the meeting (usually on Monday when the weekly meetings email is sent) clean up this document.
-    1. Check that the previous meeting's minutes were published on the [website](https://hepsoftwarefoundation.org/organization/minutes.html). If not, see if there is a [pull request](https://github.com/HSF/hsf.github.io/pulls) and remind people to edit/accept that.
+2. **Prepare the minutes**: The meeting is minuted in the [live notes]({{ site.baseurl }}/howto-website.html) document. A few days before the meeting (usually on Monday when the weekly meetings email is sent) clean up this document.
+    1. Check that the previous meeting's minutes were published on the [website]({{ site.baseurl }}/organization/minutes.html). If not, see if there is a [pull request](https://github.com/HSF/hsf.github.io/pulls) and remind people to edit/accept that.
         - In the rare case where the minutes from the previous meeting have not been handled, please save a copy of the previous minutes before you start the clean up.
     2. Clean up the different sections from the last meeting (there are a few "standing items" as reminders that get left from meeting to meeting).
     3. Pre-populate the minutes with news and any other items of Activity Area information or AOB that you are aware of.
 3. **Chair the meeting**: Generally this is going through the list of news items, working group reports and AOBs. Ensure you call for comments/questions. Usually people know to pre-populate the minutes, but discussion points and comments need to be recorded. Encourage people to write these directly, but take them yourself if necessary.
     - To take proper attendance (not everyone remembers to write their name), it's a good idea to just screenshot the Zoom participants window.
-4. **Make a PR with the minutes**: Following the usual procedures for adding content to the HSF website (documented [here](https://hepsoftwarefoundation.org/howto-website.html)), make a GitHub PR to the [HSF website repository](https://github.com/HSF/hsf.github.io). 
-    - Note that all of the [previous minutes](https://github.com/HSF/hsf.github.io/tree/main/organization/_posts) are nice templates for the small number of changes between CodiMD and the GitHub Markdown for the website.
-        - **In particular, we don't publish standing reminders or *NTR* sections, just delete these.**
+4. **Make a PR with the minutes**: Following the usual procedures for adding content to the HSF website (documented [here]({{ site.baseurl }}/howto-website.html)), make a GitHub PR to the [HSF website repository](https://github.com/HSF/hsf.github.io). 
+    - Note that all of the [previous minutes](https://github.com/HSF/hsf.github.io/tree/main/organization/_posts) are nice templates for the small number of changes between CodiMD and the GitHub Markdown for the website. In particular:
+        - **The *front-matter* section must be replaced by the one present in the previous meeting minutes in Jekyll, updating the title (meeting number and date).**
+        - **We don't publish standing reminders or *NTR* sections, just delete these.**
     - Ask one of the other participants to review the PR - it avoids a lot of mistakes, typos and omissions when someone else takes a look.
     - If you don't have permission to do any of those steps, ask on the <hsf-steering@googlegroups.com> list (send your GitHub ID) and someone will set this up for you.
 


### PR DESCRIPTION
- running-meetings page linked from howto-website page
- howto-website: reference to the HSF site made relative to site.base_url rather than absolute (required to test site properly on a different machine)