### PR TITLE
Fix: Adjust navbar-brand alignment for mobile.

### DIFF
--- a/css/hsf.css
+++ b/css/hsf.css
@@ -179,7 +179,8 @@
 .navbar-brand {
  height: 40px;
  padding: 9.5px 15px;
- font-size: 15px;
+ font-size: 14px;
+ margin-top: 2px;
 }
 
 .navbar-default .navbar-nav > li > a:focus,
@@ -187,6 +188,19 @@
 .navbar-default .navbar-brand:hover{
   color: #f39c12;
 }
+
+@media (max-width: 768px) {
+  .navbar-brand {
+    font-size: 27px; 
+    padding: 8px 10px;
+    margin-top: 7px;
+  }
+
+  .navbar-nav.navbar-right ~ .navbar-brand {
+    justify-content: flex-start;
+  }
+}
+
 
 .navbar-nav>li>a {
 		padding-top: 9.5px;
@@ -399,4 +413,5 @@ figure.centered-figure {
   }
   .big-link-container a {
     min-height: 0;
+  }
 }


### PR DESCRIPTION

This PR adjusts the styling of the navbar-brand to improve its vertical alignment on mobile screens. Specifically, a margin-top is added to shift the navbar-brand slightly downward for better visual alignment on smaller devices.

Changes
Added margin-top in the media query for screens smaller than 768px.
Adjusted padding and font size to optimize the appearance on mobile devices.

![image](https://github.com/user-attachments/assets/8bb3675a-af98-4dde-ab3a-dcdb023f0e0a)


Motivation
Addresses issue #1390 , where the navbar-brand was not properly aligned on smaller screens.

Testing
Verified the alignment on different screen sizes to ensure the changes apply only to mobile devices without affecting the desktop view.

Before: 

![image](https://github.com/user-attachments/assets/cc43e979-552d-4f70-8dce-bd07c4a55fe7)


After:

![image](https://github.com/user-attachments/assets/8a6971ee-7456-4293-b108-4cbd3285ba77)


@kartikaysaxena @hegner  Could you please review this PR? Thankyou!

