### PR TITLE
Updated gsoc.md for a Typo 

### DIFF
--- a/_activities/gsoc.md
+++ b/_activities/gsoc.md
@@ -135,7 +135,7 @@ For new HEP-related groups wishing to join HSF GSoC umbrella rather than being i
 
 ## Projects in 2025
 
-Will by filled by Feb 11th.
+Will be filled by Feb 11th.
 
 {% assign current_year = "2025" %}
 {% include gsoc_project_list.ext year=current_year %}


### PR DESCRIPTION
I observed a typo in (here)[https://hepsoftwarefoundation.org/activities/gsoc.html] on the Projects section.

Currently
`Will by filled by Feb 11th.`

What it should be
`Will be filled by Feb 11th.`