### PR TITLE
GSoC25: Updated mentors.md for minor formatting inconsistency

### DIFF
--- a/_activities/gsoc.md
+++ b/_activities/gsoc.md
@@ -135,7 +135,7 @@ For new HEP-related groups wishing to join HSF GSoC umbrella rather than being i
 
 ## Projects in 2025
 
-Will by filled by Feb 11th.
+Will be filled by Feb 11th.
 
 {% assign current_year = "2025" %}
 {% include gsoc_project_list.ext year=current_year %}

--- a/gsoc/2025/mentors.md
+++ b/gsoc/2025/mentors.md
@@ -12,6 +12,6 @@ layout: plain
 * Mayank Sharma [mayank.sharma@cern.ch](mailto:mayank.sharma@cern.ch) UMich
 * Stephan Lachnit [stephan.lachnit@desy.de](mailto:stephan.lachnit@desy.de) DESY
 * Serguei Linev [S.Linev@gsi.de](mailto:S.Linev@gsi.de) GSI 
-* Giacomo Parolini [giacomo.parolini@cern.ch](mailto:giacomo.parolini@cern.ch) CERN)
+* Giacomo Parolini [giacomo.parolini@cern.ch](mailto:giacomo.parolini@cern.ch) CERN
 * Simon Spannagel [simon.spannagel@desy.de](mailto:simon.spannagel@desy.de) DESY
 * Valentin Volkl [valentin.volkl@cern.ch](mailto:valentin.volkl@cern.ch) CERN


### PR DESCRIPTION
Saw a minor inconsistency (here)[https://hepsoftwarefoundation.org/gsoc/2025/mentors.html] in the mentor list.

Currently
`Giacomo Parolini [giacomo.parolini@cern.ch](mailto:giacomo.parolini@cern.ch) CERN)`

A better format
`Giacomo Parolini [giacomo.parolini@cern.ch](mailto:giacomo.parolini@cern.ch) CERN`