### PR TITLE
GSoC25: Added hyperlink to Constellation Update project_Constellation.md

### DIFF
--- a/_gsocprojects/2025/project_Constellation.md
+++ b/_gsocprojects/2025/project_Constellation.md
@@ -11,7 +11,7 @@ description: |
   devices, that is based on widely adopted open-source network communication
   libraries and that keeps the required maintenance as low as possible.
 summary: |
-  Constellation is a control and data acquisition system for small-scale experiments.
+  [Constellation](https://constellation.pages.desy.de/) is a control and data acquisition system for small-scale experiments.
 ---
 
 {% include gsoc_project.ext %}


### PR DESCRIPTION
#### Changes or Fixes ####

Added hyperlink for Constellation, as it was there for [MCnet](https://montecarlonet.org/) and [Rucio](http://rucio.cern.ch/) in the `Projects in 2025` section.