### PR TITLE
[gsoc25] Add Christina as a mentor for CompRes

### DIFF
--- a/gsoc/2025/mentors.md
+++ b/gsoc/2025/mentors.md
@@ -9,9 +9,10 @@ layout: plain
 * Martin Barisits [martin.barisits@cern.ch](mailto:martin.barisits@cern.ch) CERN
 * Andy Buckley [andy.buckley@gla.ac.uk](mailto:andy.buckley@gla.ac.uk) UofGlasgow
 * Vipul Cariappa [vipulcariappa@gmail.com](mailto:vipulcariappa@gmail.com) CompRes
-* Chris Gutschow [chris.g@cern.ch](mailto:chris.g@cern.ch) UCLondon
 * Mateusz Fila [mateusz.jakub.fila@cern.ch](mailto:mateusz.jakub.fila@cern.ch) CERN
+* Chris Gutschow [chris.g@cern.ch](mailto:chris.g@cern.ch) UCLondon
 * Aaron Jomy [aaron.jomy@cern.ch](mailto:aaron.jomy@cern.ch) CERN/CompRes
+* Christina Koutsou [christinakoutsou22@gmail.com](mailto:@christinakoutsou22@gmail.com) CompRes
 * Stephan Lachnit [stephan.lachnit@desy.de](mailto:stephan.lachnit@desy.de) DESY
 * David Lange [david.lange@cern.ch](mailto:david.lange@cern.ch) CompRes
 * Serguei Linev [S.Linev@gsi.de](mailto:S.Linev@gsi.de) GSI 


### PR DESCRIPTION
Also reorders the list to retain second name alphabetic order