### PR TITLE
Issue #1696: Add mentors to metadata, generate mentor list automatically

### DIFF
--- a/.github/config/mdcheck.json
+++ b/.github/config/mdcheck.json
@@ -1,6 +1,9 @@
 {
   "ignorePatterns": [
     {
+      "pattern": "https://mybinder.org"
+    },
+    {
       "pattern": "https://www.sciencedirect.com/science/article/abs/pii*"
     },
     {

--- a/_gsocproposals/2025/proposal_ATLAS_lossy_compression.md
+++ b/_gsocproposals/2025/proposal_ATLAS_lossy_compression.md
@@ -9,6 +9,12 @@ organization:
 difficulty: medium
 duration: 350
 mentor_avail: July-September
+project_mentors:
+  - name: "Maciej Szymański"
+    email: "maciej.szymanski@cern.ch"
+  - name: "Peter Van Gemmeren"
+    email: "peter.van.gemmeren@cern.ch"
+
 ---
 
 ## Description
@@ -29,11 +35,6 @@ mentor_avail: July-September
 ## Requirements
 
  * C++, Python, Machine Learning
-
-## Mentors
-
-  * **[Maciej Szymański](mailto:maciej.szymanski@cern.ch)**
-  * [Peter Van Gemmeren](mailto:peter.van.gemmeren@cern.ch)
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_ATLAS_lossy_compression.md
+++ b/_gsocproposals/2025/proposal_ATLAS_lossy_compression.md
@@ -11,11 +11,14 @@ duration: 350
 mentor_avail: July-September
 project_mentors:
   - email: maciej.szymanski@cern.ch
+    organization: ANL
     first_name: Maciej
     last_name: Szymański
+    is_preferred_contact: yes
   - email: peter.van.gemmeren@cern.ch
     first_name: Peter
     last_name: Van Gemmeren
+    organization: CERN
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_ATLAS_lossy_compression.md
+++ b/_gsocproposals/2025/proposal_ATLAS_lossy_compression.md
@@ -3,18 +3,19 @@ title: Precision Recovery in Lossy-Compressed Floating Point Data for High Energ
 layout: gsoc_proposal
 project: ATLAS
 year: 2025
-organization: 
- - ANL
- - CERN
+organization:
+  - ANL
+  - CERN
 difficulty: medium
 duration: 350
 mentor_avail: July-September
 project_mentors:
-  - name: "Maciej Szymański"
-    email: "maciej.szymanski@cern.ch"
-  - name: "Peter Van Gemmeren"
-    email: "peter.van.gemmeren@cern.ch"
-
+  - email: maciej.szymanski@cern.ch
+    first_name: Maciej
+    last_name: Szymański
+  - email: peter.van.gemmeren@cern.ch
+    first_name: Peter
+    last_name: Van Gemmeren
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_BALER.md
+++ b/_gsocproposals/2025/proposal_BALER.md
@@ -14,9 +14,12 @@ project_mentors:
   - email: james.smith-7@manchester.ac.uk
     first_name: James
     last_name: Smith
+    organization: UManchester
+    is_preferred_contact: yes
   - email: caterina.doglioni@cern.ch
     first_name: Caterina
     last_name: Doglioni
+    organization: CERN
   - email: ledidukh@gmail.com
     first_name: Leonid
     last_name: Didukh

--- a/_gsocproposals/2025/proposal_BALER.md
+++ b/_gsocproposals/2025/proposal_BALER.md
@@ -9,14 +9,17 @@ organization:
   - CERN
 difficulty: medium
 duration: 350
-mentor_avail: June-August 
+mentor_avail: June-August
 project_mentors:
-  - name: "James Smith"
-    email: "james.smith-7@manchester.ac.uk"
-  - name: "Caterina Doglioni"
-    email: "caterina.doglioni@cern.ch"
-  - name: "Leonid Didukh"
-    email: "ledidukh@gmail.com"
+  - email: james.smith-7@manchester.ac.uk
+    first_name: James
+    last_name: Smith
+  - email: caterina.doglioni@cern.ch
+    first_name: Caterina
+    last_name: Doglioni
+  - email: ledidukh@gmail.com
+    first_name: Leonid
+    last_name: Didukh
 ---
 ​
 ## Short description of the project

--- a/_gsocproposals/2025/proposal_BALER.md
+++ b/_gsocproposals/2025/proposal_BALER.md
@@ -10,6 +10,13 @@ organization:
 difficulty: medium
 duration: 350
 mentor_avail: June-August 
+project_mentors:
+  - name: "James Smith"
+    email: "james.smith-7@manchester.ac.uk"
+  - name: "Caterina Doglioni"
+    email: "caterina.doglioni@cern.ch"
+  - name: "Leonid Didukh"
+    email: "ledidukh@gmail.com"
 ---
 ​
 ## Short description of the project
@@ -46,12 +53,6 @@ An improved compression performance with documentation and figures of merit that
 The candidate should have experience with the python language and a Linux environment, familiarity with AI fundamentals, and familiarity with PyTorch.
 
 Desirable skills include familiarity with AI fundamentals including transformers and/or graph neural networks, particle physics theory and experiments, PyTorch, FPGA programming and/or simulation.
-
-
-## Mentors
-   * ***[James Smith](mailto:james.smith-7@manchester.ac.uk)***
-   * [Caterina Doglioni](mailto:caterina.doglioni@cern.ch) as backup mentor
-   * [Leonid Didukh](mailto:ledidukh@gmail.com)
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_Baler-ProbabilisticCircuit.md
+++ b/_gsocproposals/2025/proposal_Baler-ProbabilisticCircuit.md
@@ -8,6 +8,11 @@ organization:
 difficulty: medium
 duration: 350
 mentor_avail: June-October (with 3 weeks mentor vacation where student will work independently with minimal guidance)
+project_mentors:
+  - name: "Leonid Didukh"
+    email: "ledidukh@gmail.com"
+  - name: "Caterina Doglioni"
+    email: "caterina.doglioni@cern.ch"
 ---
 ​
 ## Short description of the project
@@ -32,10 +37,6 @@ An improved compression performance with documentation and figures of merit that
 ## Requirements
 
 Required: Good knowledge of UNIX, Python, matplotlib, Pytorch, Julia, Pandas, ROOT. 
-
-## Mentors
-   * ***[Leonid Didukh](mailto:ledidukh@gmail.com)***
-   * [Caterina Doglioni](mailto:caterina.doglioni@cern.ch) as backup mentor
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_Baler-ProbabilisticCircuit.md
+++ b/_gsocproposals/2025/proposal_Baler-ProbabilisticCircuit.md
@@ -9,10 +9,12 @@ difficulty: medium
 duration: 350
 mentor_avail: June-October (with 3 weeks mentor vacation where student will work independently with minimal guidance)
 project_mentors:
-  - name: "Leonid Didukh"
-    email: "ledidukh@gmail.com"
-  - name: "Caterina Doglioni"
-    email: "caterina.doglioni@cern.ch"
+  - email: ledidukh@gmail.com
+    first_name: Leonid
+    last_name: Didukh
+  - email: caterina.doglioni@cern.ch
+    first_name: Caterina
+    last_name: Doglioni
 ---
 ​
 ## Short description of the project

--- a/_gsocproposals/2025/proposal_Baler-ProbabilisticCircuit.md
+++ b/_gsocproposals/2025/proposal_Baler-ProbabilisticCircuit.md
@@ -12,9 +12,11 @@ project_mentors:
   - email: ledidukh@gmail.com
     first_name: Leonid
     last_name: Didukh
+    is_preferred_contact: yes
   - email: caterina.doglioni@cern.ch
     first_name: Caterina
     last_name: Doglioni
+    organization: CERN
 ---
 ​
 ## Short description of the project

--- a/_gsocproposals/2025/proposal_BioDynamo-CART.md
+++ b/_gsocproposals/2025/proposal_BioDynamo-CART.md
@@ -6,14 +6,16 @@ year: 2025
 difficulty: medium
 duration: 350
 mentor_avail: June-October
-organization: 
+organization:
   - CERN
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "Lukas Breitwieser"
-    email: "lukas.johannes.breitwieser@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: lukas.johannes.breitwieser@cern.ch
+    first_name: Lukas
+    last_name: Breitwieser
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_BioDynamo-CART.md
+++ b/_gsocproposals/2025/proposal_BioDynamo-CART.md
@@ -9,6 +9,11 @@ mentor_avail: June-October
 organization: 
   - CERN
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "Lukas Breitwieser"
+    email: "lukas.johannes.breitwieser@cern.ch"
 ---
 
 ## Description
@@ -40,10 +45,6 @@ The final deliverable will be a fully documented, reproducible BioDynaMo simulat
 * Agent-based modeling (understanding immune dynamics)
 * Basic immunology & cancer biology (optional but helpful)
 * Data visualization (Python, Matplotlib, Seaborn)
-
-## Mentors
-* [Vassil Vassilev](mailto:vvasilev@cern.ch)
-* [Lukas Breitwieser](mailto:lukas.johannes.breitwieser@cern.ch)
 
 ## Links
 * [Mapping CAR T-Cell Design Space Using Agent-Based Models](https://www.frontiersin.org/journals/molecular-biosciences/articles/10.3389/fmolb.2022.849363/full)

--- a/_gsocproposals/2025/proposal_BioDynamo-CART.md
+++ b/_gsocproposals/2025/proposal_BioDynamo-CART.md
@@ -13,9 +13,11 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: lukas.johannes.breitwieser@cern.ch
     first_name: Lukas
     last_name: Breitwieser
+    organization: CERN
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_CLUEsteringAutotuning.md
+++ b/_gsocproposals/2025/proposal_CLUEsteringAutotuning.md
@@ -1,19 +1,21 @@
 ---
 title: Development of an auto-tuning tool for the CLUEstering library
 layout: gsoc_proposal
-project: Patatrack 
+project: Patatrack
 year: 2025
 organization: CERN
 difficulty: medium
 duration: 350
 mentor_avail: June-October
 project_mentors:
-  - name: "Simone Balducci"
-    email: "simone.balducci@cern.ch"
-    organization: "CERN UNIBO"
-  - name: "Felice Pantaleo"
-    email: "felice.pantaleo@cern.ch"
-    organization: "CERN"
+  - email: simone.balducci@cern.ch
+    organization: CERN UNIBO
+    first_name: Simone
+    last_name: Balducci
+  - email: felice.pantaleo@cern.ch
+    organization: CERN
+    first_name: Felice
+    last_name: Pantaleo
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_CLUEsteringAutotuning.md
+++ b/_gsocproposals/2025/proposal_CLUEsteringAutotuning.md
@@ -7,6 +7,13 @@ organization: CERN
 difficulty: medium
 duration: 350
 mentor_avail: June-October
+project_mentors:
+  - name: "Simone Balducci"
+    email: "simone.balducci@cern.ch"
+    organization: "CERN UNIBO"
+  - name: "Felice Pantaleo"
+    email: "felice.pantaleo@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -45,10 +52,6 @@ Interested students please contact simone.balducci@cern.ch
 * Experience with machine learning and optimization techniques
 * Experience with development of Python libraries
 
-
-## Mentors
-  * **[Simone Balducci](mailto:simone.balducci@cern.ch) (CERN UNIBO)**
-  * [Felice Pantaleo](mailto:felice.pantaleo@cern.ch) (CERN)
 
 ## Links
   * [CLUE][clue]

--- a/_gsocproposals/2025/proposal_CLUEsteringAutotuning.md
+++ b/_gsocproposals/2025/proposal_CLUEsteringAutotuning.md
@@ -12,6 +12,7 @@ project_mentors:
     organization: CERN UNIBO
     first_name: Simone
     last_name: Balducci
+    is_preferred_contact: yes
   - email: felice.pantaleo@cern.ch
     organization: CERN
     first_name: Felice

--- a/_gsocproposals/2025/proposal_CVMFS_DistributeModelFiles.md
+++ b/_gsocproposals/2025/proposal_CVMFS_DistributeModelFiles.md
@@ -8,6 +8,16 @@ organization:
 difficulty: medium
 duration: 175
 mentor_avail: June-October
+project_mentors:
+  - email: valentin.volkl@cern.ch
+    first_name: Valentin
+    last_name: Volkl
+    organization: CERN
+    is_preferred_contact: yes
+  - email: lorenzo.moneta@cern.ch
+    first_name: Lorenzo
+    last_name: Moneta
+    organization: CERN
 ---
 
 # Description
@@ -49,10 +59,6 @@ In this project proposal, we'd like to evaluate CVMFS as a means to distribute m
  * Familiarity with common ML libraries, in particular ONNX
 
 
-## Mentors
-
- * **[Valentin Volkl](mailto:valentin.volkl@cern.ch)**
- * [Lorenzo Moneta](mailto:lorenzo.moneta@cern.ch)
 
 
 ## Links

--- a/_gsocproposals/2025/proposal_Clad-ImproveTape.md
+++ b/_gsocproposals/2025/proposal_Clad-ImproveTape.md
@@ -12,6 +12,7 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: david.lange@cern.ch
     first_name: David
     last_name: Lange

--- a/_gsocproposals/2025/proposal_Clad-ImproveTape.md
+++ b/_gsocproposals/2025/proposal_Clad-ImproveTape.md
@@ -8,6 +8,11 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "David Lange"
+    email: "david.lange@cern.ch"
 ---
 
 ## Description
@@ -34,10 +39,6 @@ This project aims to improve the efficiency of the clad tape and generalize it i
 * Automatic differentiation
 * C++ programming
 * Clang frontend
-
-## Mentors
-* **[Vassil Vassilev](mailto:vvasilev@cern.ch)**
-* [David Lange](mailto:david.lange@cern.ch)
 
 ## Links
 * [Repo](https://github.com/vgvassilev/clad)

--- a/_gsocproposals/2025/proposal_Clad-ImproveTape.md
+++ b/_gsocproposals/2025/proposal_Clad-ImproveTape.md
@@ -9,10 +9,12 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "David Lange"
-    email: "david.lange@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: david.lange@cern.ch
+    first_name: David
+    last_name: Lange
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Clad-LLM.md
+++ b/_gsocproposals/2025/proposal_Clad-LLM.md
@@ -12,6 +12,7 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: david.lange@cern.ch
     first_name: David
     last_name: Lange

--- a/_gsocproposals/2025/proposal_Clad-LLM.md
+++ b/_gsocproposals/2025/proposal_Clad-LLM.md
@@ -9,6 +9,11 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "David Lange"
+    email: "david.lange@cern.ch"
 ---
 
 ## Description
@@ -36,9 +41,6 @@ Beyond performance improvements, integrating Clad with LLM training in C++ opens
 * Reasonable expertise in C++ programming
 * Background in LLM  is preferred but not required
 
-## Mentors
-* **[Vassil Vassilev](mailto:vvasilev@cern.ch)**
-* [David Lange](mailto:david.lange@cern.ch)
 
 ## Links
 * [Repo](https://github.com/vgvassilev/clad)

--- a/_gsocproposals/2025/proposal_Clad-LLM.md
+++ b/_gsocproposals/2025/proposal_Clad-LLM.md
@@ -1,6 +1,5 @@
 ---
 title: Enhancing LLM Training with Clad for efficient differentiation
-
 layout: gsoc_proposal
 project: Clad
 year: 2025
@@ -10,10 +9,12 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "David Lange"
-    email: "david.lange@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: david.lange@cern.ch
+    first_name: David
+    last_name: Lange
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Clad-ONNX.md
+++ b/_gsocproposals/2025/proposal_Clad-ONNX.md
@@ -12,6 +12,7 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: david.lange@cern.ch
     first_name: David
     last_name: Lange

--- a/_gsocproposals/2025/proposal_Clad-ONNX.md
+++ b/_gsocproposals/2025/proposal_Clad-ONNX.md
@@ -8,6 +8,11 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "David Lange"
+    email: "david.lange@cern.ch"
 ---
 
 ## Description
@@ -34,10 +39,6 @@ This project aims to integrate Clad, an automatic differentiation (AD) plugin fo
 * Parallel programming
 * Reasonable expertise in C++ programming
 * Basic knowledge of Clang is preferred but not mandatory
-
-## Mentors
-* **[Vassil Vassilev](mailto:vvasilev@cern.ch)**
-* [David Lange](mailto:david.lange@cern.ch)
 
 ## Links
 * [Repo](https://github.com/vgvassilev/clad)

--- a/_gsocproposals/2025/proposal_Clad-ONNX.md
+++ b/_gsocproposals/2025/proposal_Clad-ONNX.md
@@ -9,10 +9,12 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "David Lange"
-    email: "david.lange@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: david.lange@cern.ch
+    first_name: David
+    last_name: Lange
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Clad-OpenMP.md
+++ b/_gsocproposals/2025/proposal_Clad-OpenMP.md
@@ -12,6 +12,7 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: david.lange@cern.ch
     first_name: David
     last_name: Lange

--- a/_gsocproposals/2025/proposal_Clad-OpenMP.md
+++ b/_gsocproposals/2025/proposal_Clad-OpenMP.md
@@ -9,10 +9,12 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "David Lange"
-    email: "david.lange@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: david.lange@cern.ch
+    first_name: David
+    last_name: Lange
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Clad-OpenMP.md
+++ b/_gsocproposals/2025/proposal_Clad-OpenMP.md
@@ -8,6 +8,11 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "David Lange"
+    email: "david.lange@cern.ch"
 ---
 
 ## Description
@@ -30,10 +35,6 @@ This project aims to develop infrastructure in Clad to support the differentiati
 * Automatic differentiation
 * C++ programming
 * Parallel Programming
-
-## Mentors
-* **[Vassil Vassilev](mailto:vvasilev@cern.ch)**
-* [David Lange](mailto:david.lange@cern.ch)
 
 ## Links
 * [Repo](https://github.com/vgvassilev/clad)

--- a/_gsocproposals/2025/proposal_Clad-PyTorch.md
+++ b/_gsocproposals/2025/proposal_Clad-PyTorch.md
@@ -12,6 +12,7 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: david.lange@cern.ch
     first_name: David
     last_name: Lange

--- a/_gsocproposals/2025/proposal_Clad-PyTorch.md
+++ b/_gsocproposals/2025/proposal_Clad-PyTorch.md
@@ -8,6 +8,11 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "David Lange"
+    email: "david.lange@cern.ch"
 ---
 
 ## Description
@@ -32,9 +37,6 @@ This project aims to integrate Clad-generated functions into PyTorch using its C
 * C++ programming
 * Clang frontend
 
-## Mentors
-* **[Vassil Vassilev](mailto:vvasilev@cern.ch)**
-* [David Lange](mailto:david.lange@cern.ch)
 
 ## Links
 * [Repo](https://github.com/vgvassilev/clad)

--- a/_gsocproposals/2025/proposal_Clad-PyTorch.md
+++ b/_gsocproposals/2025/proposal_Clad-PyTorch.md
@@ -9,10 +9,12 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "David Lange"
-    email: "david.lange@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: david.lange@cern.ch
+    first_name: David
+    last_name: Lange
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Clad-STLConcurrency.md
+++ b/_gsocproposals/2025/proposal_Clad-STLConcurrency.md
@@ -12,6 +12,7 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: david.lange@cern.ch
     first_name: David
     last_name: Lange

--- a/_gsocproposals/2025/proposal_Clad-STLConcurrency.md
+++ b/_gsocproposals/2025/proposal_Clad-STLConcurrency.md
@@ -8,6 +8,11 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "David Lange"
+    email: "david.lange@cern.ch"
 ---
 
 ## Description
@@ -119,9 +124,6 @@ int main() {
 * Parallel programming
 * Reasonable expertise in C++ programming
 
-## Mentors
-* **[Vassil Vassilev](mailto:vvasilev@cern.ch)**
-* [David Lange](mailto:david.lange@cern.ch)
 
 ## Links
 * [Repo](https://github.com/vgvassilev/clad)

--- a/_gsocproposals/2025/proposal_Clad-STLConcurrency.md
+++ b/_gsocproposals/2025/proposal_Clad-STLConcurrency.md
@@ -9,10 +9,12 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "David Lange"
-    email: "david.lange@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: david.lange@cern.ch
+    first_name: David
+    last_name: Lange
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Clad-ThrustAPI.md
+++ b/_gsocproposals/2025/proposal_Clad-ThrustAPI.md
@@ -12,6 +12,7 @@ project_mentors:
   - email: vvasilev@cern.ch
     first_name: Vassil
     last_name: Vassilev
+    is_preferred_contact: yes
   - email: david.lange@cern.ch
     first_name: David
     last_name: Lange

--- a/_gsocproposals/2025/proposal_Clad-ThrustAPI.md
+++ b/_gsocproposals/2025/proposal_Clad-ThrustAPI.md
@@ -8,6 +8,11 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+  - name: "David Lange"
+    email: "david.lange@cern.ch"
 ---
 
 ## Description
@@ -30,10 +35,6 @@ Clad is a clang plugin for automatic differentiation that performs source-to-sou
 * Automatic differentiation
 * C++ programming
 * Clang frontend
-
-## Mentors
-* **[Vassil Vassilev](mailto:vvasilev@cern.ch)**
-* [David Lange](mailto:david.lange@cern.ch)
 
 ## Links
 * [Repo](https://github.com/vgvassilev/clad)

--- a/_gsocproposals/2025/proposal_Clad-ThrustAPI.md
+++ b/_gsocproposals/2025/proposal_Clad-ThrustAPI.md
@@ -9,10 +9,12 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-  - name: "David Lange"
-    email: "david.lange@cern.ch"
+  - email: vvasilev@cern.ch
+    first_name: Vassil
+    last_name: Vassilev
+  - email: david.lange@cern.ch
+    first_name: David
+    last_name: Lange
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_ConstellationUI.md
+++ b/_gsocproposals/2025/proposal_ConstellationUI.md
@@ -8,12 +8,14 @@ difficulty: medium
 duration: 350
 mentor_avail: June-August
 project_mentors:
-  - name: "Stephan Lachnit"
-    email: "stephan.lachnit@desy.de"
-    organization: "DESY"
-  - name: "Simon Spannagel"
-    email: "simon.spannagel@desy.de"
-    organization: "DESY"
+  - email: stephan.lachnit@desy.de
+    organization: DESY
+    first_name: Stephan
+    last_name: Lachnit
+  - email: simon.spannagel@desy.de
+    organization: DESY
+    first_name: Simon
+    last_name: Spannagel
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_ConstellationUI.md
+++ b/_gsocproposals/2025/proposal_ConstellationUI.md
@@ -7,6 +7,13 @@ organization: DESY
 difficulty: medium
 duration: 350
 mentor_avail: June-August
+project_mentors:
+  - name: "Stephan Lachnit"
+    email: "stephan.lachnit@desy.de"
+    organization: "DESY"
+  - name: "Simon Spannagel"
+    email: "simon.spannagel@desy.de"
+    organization: "DESY"
 ---
 
 ## Description
@@ -32,10 +39,6 @@ user interfaces to Constellation and extend the current ones.
 * Knowledge of Qt is helpful but not required
 * Practical experience with Unix and git
 
-## Mentors
-
-* [Stephan Lachnit](mailto:stephan.lachnit@desy.de) (DESY)
-* [Simon Spannagel](mailto:simon.spannagel@desy.de) (DESY)
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_CppInterop-API-ExposeMemory.md
+++ b/_gsocproposals/2025/proposal_CppInterop-API-ExposeMemory.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: CompRes
     first_name: Aaron
     last_name: Jomy
+    is_preferred_contact: yes
   - email: vvasilev@cern.ch
     organization: CompRes
     first_name: Vassil

--- a/_gsocproposals/2025/proposal_CppInterop-API-ExposeMemory.md
+++ b/_gsocproposals/2025/proposal_CppInterop-API-ExposeMemory.md
@@ -1,5 +1,5 @@
 ---
-title: Implement CppInterOp API exposing memory, ownership and thread safety information 
+title: Implement CppInterOp API exposing memory, ownership and thread safety information
 layout: gsoc_proposal
 project: CppInterOp
 year: 2025
@@ -9,12 +9,14 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Aaron Jomy"
-    email: "aaron.jomy@cern.ch"
-    organization: "CompRes"
-  - name: "Vassil Vassilev"
-    email: "vvasilev@cern.ch"
-    organization: "CompRes"
+  - email: aaron.jomy@cern.ch
+    organization: CompRes
+    first_name: Aaron
+    last_name: Jomy
+  - email: vvasilev@cern.ch
+    organization: CompRes
+    first_name: Vassil
+    last_name: Vassilev
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_CppInterop-API-ExposeMemory.md
+++ b/_gsocproposals/2025/proposal_CppInterop-API-ExposeMemory.md
@@ -8,6 +8,13 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Aaron Jomy"
+    email: "aaron.jomy@cern.ch"
+    organization: "CompRes"
+  - name: "Vassil Vassilev"
+    email: "vvasilev@cern.ch"
+    organization: "CompRes"
 ---
 
 ## Description
@@ -30,11 +37,6 @@ Clang and LLVM provide access to C++ from other programming languages, but curre
 * C++ programming
 * Python programming
 * Knowledge of Clang and LLVM
-
-## Mentors
-* **[Aaron Jomy](mailto:aaron.jomy@cern.ch)**
-* [Vassil Vassilev](mailto:vvasilev@cern.ch)
-
 
 ## Links
 * [Repo](https://github.com/compiler-research/CppInterOp)

--- a/_gsocproposals/2025/proposal_GangaAIassistant.md
+++ b/_gsocproposals/2025/proposal_GangaAIassistant.md
@@ -9,6 +9,16 @@ mentor_avail: May-November
 organization:
   - ImperialCollege
   - MonashUniversity
+project_mentors:
+  - name: "Alex Richards"
+    email: "a.richards@imperial.ac.uk"
+    organization: "Imperial College"
+  - name: "Mark Smith"
+    email: "mark.smith1@imperial.ac.uk"
+    organization: "Imperial College"
+  - name: "Ulrik Egede"
+    email: "ulrik.egede@monash.edu"
+    organization: "Monash University"
 ---
 
 ## Description
@@ -35,11 +45,5 @@ Interested students please contact Ulrik (see contact below) to ask questions an
 
 ## Requirements
 Python programming (advanced), Linux command line experience (intermediate), use of git for code development and continuous integration testing (intermediate)
-
-## Mentors 
-  * [Alex Richards](mailto:a.richards@imperial.ac.uk)
-  * [Mark Smith](mailto:mark.smith1@imperial.ac.uk)
-  * **[Ulrik Egede](mailto:ulrik.egede@monash.edu)**
-
 ## Links
   * [Ganga](https://github.com/ganga-devs/ganga)

--- a/_gsocproposals/2025/proposal_GangaAIassistant.md
+++ b/_gsocproposals/2025/proposal_GangaAIassistant.md
@@ -10,15 +10,18 @@ organization:
   - ImperialCollege
   - MonashUniversity
 project_mentors:
-  - name: "Alex Richards"
-    email: "a.richards@imperial.ac.uk"
-    organization: "Imperial College"
-  - name: "Mark Smith"
-    email: "mark.smith1@imperial.ac.uk"
-    organization: "Imperial College"
-  - name: "Ulrik Egede"
-    email: "ulrik.egede@monash.edu"
-    organization: "Monash University"
+  - email: a.richards@imperial.ac.uk
+    organization: Imperial College
+    first_name: Alex
+    last_name: Richards
+  - email: mark.smith1@imperial.ac.uk
+    organization: Imperial College
+    first_name: Mark
+    last_name: Smith
+  - email: ulrik.egede@monash.edu
+    organization: Monash University
+    first_name: Ulrik
+    last_name: Egede
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_GangaAIassistant.md
+++ b/_gsocproposals/2025/proposal_GangaAIassistant.md
@@ -22,6 +22,7 @@ project_mentors:
     organization: Monash University
     first_name: Ulrik
     last_name: Egede
+    is_preferred_contact: yes
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_GangaDeprecation.md
+++ b/_gsocproposals/2025/proposal_GangaDeprecation.md
@@ -9,6 +9,16 @@ mentor_avail: May-November
 organization:
   - ImperialCollege
   - MonashUniversity
+project_mentors:
+  - name: "Alex Richards"
+    email: "a.richards@imperial.ac.uk"
+    organization: "Imperial College"
+  - name: "Mark Smith"
+    email: "mark.smith1@imperial.ac.uk"
+    organization: "Imperial College"
+  - name: "Ulrik Egede"
+    email: "ulrik.egede@monash.edu"
+    organization: "Monash University"
 ---
 
 ## Description
@@ -35,11 +45,5 @@ Interested students please contact Ulrik (see contact below) to ask questions an
 
 ## Requirements
 Python programming (advanced), Linux command line experience (intermediate), use of git for code development and continuous integration testing (intermediate)
-
-## Mentors 
-  * [Alex Richards](mailto:a.richards@imperial.ac.uk)
-  * [Mark Smith](mailto:mark.smith1@imperial.ac.uk)
-  * **[Ulrik Egede](mailto:ulrik.egede@monash.edu)**
-
 ## Links
   * [Ganga](https://github.com/ganga-devs/ganga)

--- a/_gsocproposals/2025/proposal_GangaDeprecation.md
+++ b/_gsocproposals/2025/proposal_GangaDeprecation.md
@@ -10,15 +10,18 @@ organization:
   - ImperialCollege
   - MonashUniversity
 project_mentors:
-  - name: "Alex Richards"
-    email: "a.richards@imperial.ac.uk"
-    organization: "Imperial College"
-  - name: "Mark Smith"
-    email: "mark.smith1@imperial.ac.uk"
-    organization: "Imperial College"
-  - name: "Ulrik Egede"
-    email: "ulrik.egede@monash.edu"
-    organization: "Monash University"
+  - email: a.richards@imperial.ac.uk
+    organization: Imperial College
+    first_name: Alex
+    last_name: Richards
+  - email: mark.smith1@imperial.ac.uk
+    organization: Imperial College
+    first_name: Mark
+    last_name: Smith
+  - email: ulrik.egede@monash.edu
+    organization: Monash University
+    first_name: Ulrik
+    last_name: Egede
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_GangaDeprecation.md
+++ b/_gsocproposals/2025/proposal_GangaDeprecation.md
@@ -22,6 +22,7 @@ project_mentors:
     organization: Monash University
     first_name: Ulrik
     last_name: Egede
+    is_preferred_contact: yes
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
+++ b/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
@@ -9,15 +9,18 @@ mentor_avail: June-October
 organization:
   - CERN
 project_mentors:
-  - name: "Peter McKeown"
-    email: "peter.mckeown@cern.ch"
-    organization: "CERN"
-  - name: "Piyush Raikwar"
-    email: "piyush.raikwar@cern.ch"
-    organization: "CERN"
-  - name: "Anna Zaborowska"
-    email: "anna.zaborowska@cern.ch"
-    organization: "CERN"
+  - email: peter.mckeown@cern.ch
+    organization: CERN
+    first_name: Peter
+    last_name: McKeown
+  - email: piyush.raikwar@cern.ch
+    organization: CERN
+    first_name: Piyush
+    last_name: Raikwar
+  - email: anna.zaborowska@cern.ch
+    organization: CERN
+    first_name: Anna
+    last_name: Zaborowska
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
+++ b/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
@@ -8,6 +8,16 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CERN
+project_mentors:
+  - name: "Peter McKeown"
+    email: "peter.mckeown@cern.ch"
+    organization: "CERN"
+  - name: "Piyush Raikwar"
+    email: "piyush.raikwar@cern.ch"
+    organization: "CERN"
+  - name: "Anna Zaborowska"
+    email: "anna.zaborowska@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -44,12 +54,6 @@ A shower representation which has the potential to meet these criteria is a poin
 1. Find the test [here](https://docs.google.com/document/d/1XYF8xFfprqiYYnjxu7Bzm8Ps-s646VJhIkDCQJd8n_8/edit?usp=sharing). Please submit it by 9:00 CET 17th March 2025 along with a short proposal (2 pages max) describing how you would approach the problem. See submission instructions in the test doc. Please don't forget to start the subject line with "GSoC'25 FastSim".
 2. We will make the selections based on the test, short proposal and resume by 17:00 CET 24th March.
 3. Selected candidates will then write the full proposal and submit it according to the official GSoC timeline.
-
-## Mentors
-(As we typically receive a large number of responses and we are not able to reply to all initial messages, please only contact us after completing the test)
-* [Peter McKeown](mailto:peter.mckeown@cern.ch) (CERN)
-* Piyush Raikwar (CERN)
-* Anna Zaborowska (CERN)
 
 ## Links
 * [G4FastSim](https://g4fastsim.web.cern.ch/)

--- a/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
+++ b/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
@@ -13,12 +13,11 @@ project_mentors:
     organization: CERN
     first_name: Peter
     last_name: McKeown
-  - email: piyush.raikwar@cern.ch
-    organization: CERN
+    is_preferred_contact: yes
+  - organization: CERN
     first_name: Piyush
     last_name: Raikwar
-  - email: anna.zaborowska@cern.ch
-    organization: CERN
+  - organization: CERN
     first_name: Anna
     last_name: Zaborowska
 ---

--- a/_gsocproposals/2025/proposal_GeneROOT.md
+++ b/_gsocproposals/2025/proposal_GeneROOT.md
@@ -6,19 +6,22 @@ year: 2025
 difficulty: medium
 duration: 350
 mentor_avail: June-November
-organization: 
+organization:
   - CERN
   - CompRes
 project_mentors:
-  - name: "Martin Vasilev"
-    email: "mvassilev@uni-plovdiv.bg"
-    organization: "Uni Plovdiv"
-  - name: "Jonas Rembser"
-    email: "Jonas.Rembser@cern.ch"
-    organization: "CERN"
-  - name: "Fons Rademakers"
-    email: "Fons.Rademakers@cern.ch"
-    organization: "CERN"
+  - email: mvassilev@uni-plovdiv.bg
+    organization: Uni Plovdiv
+    first_name: Martin
+    last_name: Vasilev
+  - email: Jonas.Rembser@cern.ch
+    organization: CERN
+    first_name: Jonas
+    last_name: Rembser
+  - email: Fons.Rademakers@cern.ch
+    organization: CERN
+    first_name: Fons
+    last_name: Rademakers
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_GeneROOT.md
+++ b/_gsocproposals/2025/proposal_GeneROOT.md
@@ -9,6 +9,16 @@ mentor_avail: June-November
 organization: 
   - CERN
   - CompRes
+project_mentors:
+  - name: "Martin Vasilev"
+    email: "mvassilev@uni-plovdiv.bg"
+    organization: "Uni Plovdiv"
+  - name: "Jonas Rembser"
+    email: "Jonas.Rembser@cern.ch"
+    organization: "CERN"
+  - name: "Fons Rademakers"
+    email: "Fons.Rademakers@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -41,13 +51,6 @@ requirements of the field.
 * C++ and Python programming
 * Familiarity with Git
 * Knowledge of ROOT and/or the BAM file formats is a plus.
-
-
-## Mentors
-* [Martin Vasilev](mailto:mvassilev@uni-plovdiv.bg)
-* [Jonas Rembser](mailto:Jonas.Rembser@cern.ch)
-* [Fons Rademakers](mailto:Fons.Rademakers@cern.ch)
-
 
 ## Links
 * [Latest Presentation on GeneROOT](https://indico.cern.ch/event/655464/)

--- a/_gsocproposals/2025/proposal_HGQforCICADA.md
+++ b/_gsocproposals/2025/proposal_HGQforCICADA.md
@@ -7,6 +7,16 @@ difficulty: medium
 duration: 350
 mentor_avail: Flexible
 organization: princeton
+project_mentors:
+  - name: "Lino Gerlach"
+    email: "lino.oscar.gerlach@cern.ch"
+    organization: "CERN"
+  - name: "Isobel Ojalvo"
+    email: "iojalvo@princeton.edu"
+    organization: "Princeton"
+  - name: "Jennifer Ngadiuba"
+    email: "jennifer.ngadiuba@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -26,12 +36,6 @@ The CICADA (Calorimeter Image Convolutional Anomaly Detection Algorithm) project
 
 ## Requirements
 Python, Tensorflow, Quantization
-
-## Mentors
-  * [Lino Gerlach](mailto:lino.oscar.gerlach@cern.ch)
-  * [Isobel Ojalvo](mailto:iojalvo@princeton.edu)
-  * [Jennifer Ngadiuba](mailto:jennifer.ngadiuba@cern.ch)
-  
 ## Links
   * [CICADA (homepage)](https://cicada.web.cern.ch/)
   * [CICADA (code)](https://github.com/Princeton-AD/cicada)

--- a/_gsocproposals/2025/proposal_HGQforCICADA.md
+++ b/_gsocproposals/2025/proposal_HGQforCICADA.md
@@ -8,15 +8,18 @@ duration: 350
 mentor_avail: Flexible
 organization: princeton
 project_mentors:
-  - name: "Lino Gerlach"
-    email: "lino.oscar.gerlach@cern.ch"
-    organization: "CERN"
-  - name: "Isobel Ojalvo"
-    email: "iojalvo@princeton.edu"
-    organization: "Princeton"
-  - name: "Jennifer Ngadiuba"
-    email: "jennifer.ngadiuba@cern.ch"
-    organization: "CERN"
+  - email: lino.oscar.gerlach@cern.ch
+    organization: CERN
+    first_name: Lino
+    last_name: Gerlach
+  - email: iojalvo@princeton.edu
+    organization: Princeton
+    first_name: Isobel
+    last_name: Ojalvo
+  - email: jennifer.ngadiuba@cern.ch
+    organization: CERN
+    first_name: Jennifer
+    last_name: Ngadiuba
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_HSFCondDB_AILogAnalysis.md
+++ b/_gsocproposals/2025/proposal_HSFCondDB_AILogAnalysis.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: BNL
     first_name: Ruslan
     last_name: Mashinistov
+    is_preferred_contact: yes
   - email: jd@bnl.gov
     organization: BNL
     first_name: John S.

--- a/_gsocproposals/2025/proposal_HSFCondDB_AILogAnalysis.md
+++ b/_gsocproposals/2025/proposal_HSFCondDB_AILogAnalysis.md
@@ -1,5 +1,5 @@
 ---
-title: Intelligent Log Analysis for the HSF Conditions Database 
+title: Intelligent Log Analysis for the HSF Conditions Database
 layout: gsoc_proposal
 project: HSFCondDB
 year: 2025
@@ -9,15 +9,18 @@ mentor_avail: June-October
 organization:
   - BNL
 project_mentors:
-  - name: "Ruslan Mashinistov"
-    email: "mashinistov@bnl.gov"
-    organization: "BNL"
-  - name: "John S. De Stefano Jr."
-    email: "jd@bnl.gov"
-    organization: "BNL"
-  - name: "Michel Hernandez Villanueva"
-    email: "mhernande1@bnl.gov"
-    organization: "BNL"
+  - email: mashinistov@bnl.gov
+    organization: BNL
+    first_name: Ruslan
+    last_name: Mashinistov
+  - email: jd@bnl.gov
+    organization: BNL
+    first_name: John S.
+    last_name: De Stefano Jr.
+  - email: mhernande1@bnl.gov
+    organization: BNL
+    first_name: Michel
+    last_name: Hernandez Villanueva
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_HSFCondDB_AILogAnalysis.md
+++ b/_gsocproposals/2025/proposal_HSFCondDB_AILogAnalysis.md
@@ -8,6 +8,16 @@ duration: 350
 mentor_avail: June-October
 organization:
   - BNL
+project_mentors:
+  - name: "Ruslan Mashinistov"
+    email: "mashinistov@bnl.gov"
+    organization: "BNL"
+  - name: "John S. De Stefano Jr."
+    email: "jd@bnl.gov"
+    organization: "BNL"
+  - name: "Michel Hernandez Villanueva"
+    email: "mhernande1@bnl.gov"
+    organization: "BNL"
 ---
 
 ## Description
@@ -44,13 +54,6 @@ adjustment of parameters during periods of increased request rates.
 * Kubernetes, basic understanding, k8s, Helm, Operators, OpenShift
 * Django and Nginx, basic understanding of web frameworks and logging
 * Database knowledge, PostgreSQL, database replication
-
-
-## Mentors
-
-- **Ruslan Mashinistov [mashinistov@bnl.gov](mailto:mashinistov@bnl.gov) BNL** 
-- John S. De Stefano Jr. [jd@bnl.gov](mailto:jd@bnl.gov) BNL
-- Michel Hernandez Villanueva [mhernande1@bnl.gov](mailto:mhernande1@bnl.gov) BNL
 
 
 ## Links

--- a/_gsocproposals/2025/proposal_IDD.md
+++ b/_gsocproposals/2025/proposal_IDD.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: CompRes
     first_name: Vipul
     last_name: Cariappa
+    is_preferred_contact: yes
   - email: mvassilev@uni-plovdiv.bg
     organization: University of Plovdiv
     first_name: Martin

--- a/_gsocproposals/2025/proposal_IDD.md
+++ b/_gsocproposals/2025/proposal_IDD.md
@@ -9,12 +9,14 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Vipul Cariappa"
-    email: "vipulcariappa@gmail.com"
-    organization: "CompRes"
-  - name: "Martin Vasilev"
-    email: "mvassilev@uni-plovdiv.bg"
-    organization: "University of Plovdiv"
+  - email: vipulcariappa@gmail.com
+    organization: CompRes
+    first_name: Vipul
+    last_name: Cariappa
+  - email: mvassilev@uni-plovdiv.bg
+    organization: University of Plovdiv
+    first_name: Martin
+    last_name: Vasilev
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_IDD.md
+++ b/_gsocproposals/2025/proposal_IDD.md
@@ -8,6 +8,13 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Vipul Cariappa"
+    email: "vipulcariappa@gmail.com"
+    organization: "CompRes"
+  - name: "Martin Vasilev"
+    email: "mvassilev@uni-plovdiv.bg"
+    organization: "University of Plovdiv"
 ---
 
 ## Description
@@ -30,10 +37,6 @@ This project aims to implement intelligent stepping (debugging) and tab completi
 
 * Python & C/C++ programming
 * Familiarity debugging with GDB/LLDB
-
-## Mentors
-* **[Vipul Cariappa](mailto:vipulcariappa@gmail.com)**
-* [Martin Vasilev](mailto:mvassilev@uni-plovdiv.bg)
 
 ## Links
 * [IDD Repository](https://github.com/compiler-research/idd)

--- a/_gsocproposals/2025/proposal_JuliaHepMC3.md
+++ b/_gsocproposals/2025/proposal_JuliaHepMC3.md
@@ -4,17 +4,19 @@ layout: gsoc_proposal
 project: JuliaHEP
 year: 2025
 organization:
-    - CERN
+  - CERN
 difficulty: medium
 duration: 175
 mentor_avail: June-July- August
 project_mentors:
-  - name: "Graeme Stewart"
-    email: "graeme.andrew.stewart@cern.ch"
-    organization: "CERN"
-  - name: "Mateusz Fila"
-    email: "mateusz.jakub.fila@cern.ch"
-    organization: "CERN"
+  - email: graeme.andrew.stewart@cern.ch
+    organization: CERN
+    first_name: Graeme
+    last_name: Stewart
+  - email: mateusz.jakub.fila@cern.ch
+    organization: CERN
+    first_name: Mateusz
+    last_name: Fila
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_JuliaHepMC3.md
+++ b/_gsocproposals/2025/proposal_JuliaHepMC3.md
@@ -8,6 +8,13 @@ organization:
 difficulty: medium
 duration: 175
 mentor_avail: June-July- August
+project_mentors:
+  - name: "Graeme Stewart"
+    email: "graeme.andrew.stewart@cern.ch"
+    organization: "CERN"
+  - name: "Mateusz Fila"
+    email: "mateusz.jakub.fila@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -49,11 +56,6 @@ A key outcome would be a set of unit tests and examples, based on the HepMC3 one
 ## Evaluation Exercise
 
 TBD
-
-## Mentors
-
-- **[Graeme Stewart](mailto:graeme.andrew.stewart@cern.ch)**
-- [Mateusz Fila](mailto:mateusz.jakub.fila@cern.ch)
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_JuliaHepMC3.md
+++ b/_gsocproposals/2025/proposal_JuliaHepMC3.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: CERN
     first_name: Graeme
     last_name: Stewart
+    is_preferred_contact: yes
   - email: mateusz.jakub.fila@cern.ch
     organization: CERN
     first_name: Mateusz

--- a/_gsocproposals/2025/proposal_MCnetMCviz.md
+++ b/_gsocproposals/2025/proposal_MCnetMCviz.md
@@ -8,6 +8,13 @@ organization:
 difficulty: medium
 duration: 350
 mentor_avail: June-October
+project_mentors:
+  - name: "Andy Buckley"
+    email: "andy.buckley@cern.ch"
+    organization: "CERN"
+  - name: "Chris Gutschow"
+    email: "chris.g@cern.ch"
+    organization: "CERN"
 ---
 
 # Description
@@ -49,11 +56,6 @@ useful both to physicists and for public outreach.
  * Web technologies
  * Gitlab CI
  * git
-
-## Mentors
-
- * **[Andy Buckley](mailto:andy.buckley@cern.ch)**
- * [Chris Gutschow](mailto:chris.g@cern.ch)
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_MCnetMCviz.md
+++ b/_gsocproposals/2025/proposal_MCnetMCviz.md
@@ -9,12 +9,14 @@ difficulty: medium
 duration: 350
 mentor_avail: June-October
 project_mentors:
-  - name: "Andy Buckley"
-    email: "andy.buckley@cern.ch"
-    organization: "CERN"
-  - name: "Chris Gutschow"
-    email: "chris.g@cern.ch"
-    organization: "CERN"
+  - email: andy.buckley@cern.ch
+    organization: CERN
+    first_name: Andy
+    last_name: Buckley
+  - email: chris.g@cern.ch
+    organization: CERN
+    first_name: Chris
+    last_name: Gutschow
 ---
 
 # Description

--- a/_gsocproposals/2025/proposal_MCnetMCviz.md
+++ b/_gsocproposals/2025/proposal_MCnetMCviz.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: CERN
     first_name: Andy
     last_name: Buckley
+    is_preferred_contact: yes
   - email: chris.g@cern.ch
     organization: CERN
     first_name: Chris

--- a/_gsocproposals/2025/proposal_MCnetOpenData.md
+++ b/_gsocproposals/2025/proposal_MCnetOpenData.md
@@ -9,12 +9,14 @@ difficulty: medium
 duration: 175
 mentor_avail: June-October
 project_mentors:
-  - name: "Andy Buckley"
-    email: "andy.buckley@cern.ch"
-    organization: "CERN"
-  - name: "Chris Gutschow"
-    email: "chris.g@cern.ch"
-    organization: "CERN"
+  - email: andy.buckley@cern.ch
+    organization: CERN
+    first_name: Andy
+    last_name: Buckley
+  - email: chris.g@cern.ch
+    organization: CERN
+    first_name: Chris
+    last_name: Gutschow
 ---
 
 # Description

--- a/_gsocproposals/2025/proposal_MCnetOpenData.md
+++ b/_gsocproposals/2025/proposal_MCnetOpenData.md
@@ -2,7 +2,7 @@
 title: MCnet/OpenData - tools and exercises for open-data exploration with MC simulations
 layout: gsoc_proposal
 project: MCnet
-year: 2024
+year: 2025
 organization:
   - UofGlasgow
 difficulty: medium
@@ -13,6 +13,7 @@ project_mentors:
     organization: CERN
     first_name: Andy
     last_name: Buckley
+    is_preferred_contact: yes
   - email: chris.g@cern.ch
     organization: CERN
     first_name: Chris

--- a/_gsocproposals/2025/proposal_MCnetOpenData.md
+++ b/_gsocproposals/2025/proposal_MCnetOpenData.md
@@ -8,6 +8,13 @@ organization:
 difficulty: medium
 duration: 175
 mentor_avail: June-October
+project_mentors:
+  - name: "Andy Buckley"
+    email: "andy.buckley@cern.ch"
+    organization: "CERN"
+  - name: "Chris Gutschow"
+    email: "chris.g@cern.ch"
+    organization: "CERN"
 ---
 
 # Description
@@ -45,11 +52,6 @@ engaging exercises with hypothetical new-physics models.
  * Binder
  * Gitlab CI
  * git
-
-## Mentors
-
- * **[Andy Buckley](mailto:andy.buckley@cern.ch)**
- * [Chris Gutschow](mailto:chris.g@cern.ch)
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_RNTupleJsroot.md
+++ b/_gsocproposals/2025/proposal_RNTupleJsroot.md
@@ -7,6 +7,13 @@ organization: CERN
 difficulty: medium
 duration: 350
 mentor_avail: June-October
+project_mentors:
+  - name: "Serguei Linev"
+    email: "S.Linev@gsi.de"
+    organization: "CERN"
+  - name: "Giacomo Parolini"
+    email: "giacomo.parolini@cern.ch"
+    organization: "CERN"
 ---
 
 # Description
@@ -29,10 +36,6 @@ In this project, the student will learn the internals of the RNTuple binary form
   * Basic knowledge of "low-level" programming (primitive types binary layouts, bit-level manipulations, reinterpreting bytes as different types, ...)
   * Experience with git / github
   * (Bonus): familiarity with any binary format
-
-## Mentors
-  * **[Serguei Linev](mailto:S.Linev@gsi.de)**
-  * [Giacomo Parolini](mailto:giacomo.parolini@cern.ch)
 
 ## Links
   * [ROOT Project homepage](https://root.cern/)

--- a/_gsocproposals/2025/proposal_RNTupleJsroot.md
+++ b/_gsocproposals/2025/proposal_RNTupleJsroot.md
@@ -8,12 +8,14 @@ difficulty: medium
 duration: 350
 mentor_avail: June-October
 project_mentors:
-  - name: "Serguei Linev"
-    email: "S.Linev@gsi.de"
-    organization: "CERN"
-  - name: "Giacomo Parolini"
-    email: "giacomo.parolini@cern.ch"
-    organization: "CERN"
+  - email: S.Linev@gsi.de
+    organization: CERN
+    first_name: Serguei
+    last_name: Linev
+  - email: giacomo.parolini@cern.ch
+    organization: CERN
+    first_name: Giacomo
+    last_name: Parolini
 ---
 
 # Description

--- a/_gsocproposals/2025/proposal_RNTupleJsroot.md
+++ b/_gsocproposals/2025/proposal_RNTupleJsroot.md
@@ -12,6 +12,7 @@ project_mentors:
     organization: CERN
     first_name: Serguei
     last_name: Linev
+    is_preferred_contact: yes
   - email: giacomo.parolini@cern.ch
     organization: CERN
     first_name: Giacomo

--- a/_gsocproposals/2025/proposal_Rucio-webui.md
+++ b/_gsocproposals/2025/proposal_Rucio-webui.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: University of Michigan, Ann Arbor
     first_name: Mayank
     last_name: Sharma
+    is_preferred_contact: yes
   - email: martin.barisits@cern.ch
     organization: CERN
     first_name: Martin

--- a/_gsocproposals/2025/proposal_Rucio-webui.md
+++ b/_gsocproposals/2025/proposal_Rucio-webui.md
@@ -7,14 +7,16 @@ difficulty: medium
 duration: 350
 mentor_avail: June-November
 organization:
-    - CERN
+  - CERN
 project_mentors:
-  - name: "Mayank Sharma"
-    email: "mayank.sharma@cern.ch"
-    organization: "University of Michigan, Ann Arbor"
-  - name: "Martin Barisits"
-    email: "martin.barisits@cern.ch"
-    organization: "CERN"
+  - email: mayank.sharma@cern.ch
+    organization: University of Michigan, Ann Arbor
+    first_name: Mayank
+    last_name: Sharma
+  - email: martin.barisits@cern.ch
+    organization: CERN
+    first_name: Martin
+    last_name: Barisits
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_Rucio-webui.md
+++ b/_gsocproposals/2025/proposal_Rucio-webui.md
@@ -8,6 +8,13 @@ duration: 350
 mentor_avail: June-November
 organization:
     - CERN
+project_mentors:
+  - name: "Mayank Sharma"
+    email: "mayank.sharma@cern.ch"
+    organization: "University of Michigan, Ann Arbor"
+  - name: "Martin Barisits"
+    email: "martin.barisits@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -69,11 +76,6 @@ By the end of GSoC 2025, we expect to have a revamped Rucio WebUI that:
 - Employs NextAuth for streamlined authentication processes.
 - Implements a robust RBAC system.
 - Adopts a monorepo structure for improved code organization and component sharing.
-
-## Mentors
-
-- **[Mayank Sharma](mailto:mayank.sharma@cern.ch)** (University of Michigan, Ann Arbor)
-- [Martin Barisits](mailto:martin.barisits@cern.ch) (CERN)
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_SMARTHEP_BEAD.md
+++ b/_gsocproposals/2025/proposal_SMARTHEP_BEAD.md
@@ -14,13 +14,15 @@ project_mentors:
     organization: CERN
     first_name: Pratik
     last_name: Jawahar
+    is_preferred_contact: yes
   - email: sukanya.sinha@cern.ch
     organization: CERN
     first_name: Sukanya
     last_name: Sinha
+    is_preferred_contact: yes
   - email: caterina.doglioni@cern.ch
     organization: CERN
-    role: Backup Mentor
+    additional_information: Backup Mentor
     first_name: Caterina
     last_name: Doglioni
 ---

--- a/_gsocproposals/2025/proposal_SMARTHEP_BEAD.md
+++ b/_gsocproposals/2025/proposal_SMARTHEP_BEAD.md
@@ -8,18 +8,21 @@ organization:
   - UManchester
 difficulty: medium
 duration: 350
-mentor_avail: June-August 
+mentor_avail: June-August
 project_mentors:
-  - name: "Pratik Jawahar"
-    email: "pratik.jawahar@cern.ch"
-    organization: "CERN"
-  - name: "Sukanya Sinha"
-    email: "sukanya.sinha@cern.ch"
-    organization: "CERN"
-  - name: "Caterina Doglioni"
-    email: "caterina.doglioni@cern.ch"
-    organization: "CERN"
-    role: "Backup Mentor"
+  - email: pratik.jawahar@cern.ch
+    organization: CERN
+    first_name: Pratik
+    last_name: Jawahar
+  - email: sukanya.sinha@cern.ch
+    organization: CERN
+    first_name: Sukanya
+    last_name: Sinha
+  - email: caterina.doglioni@cern.ch
+    organization: CERN
+    role: Backup Mentor
+    first_name: Caterina
+    last_name: Doglioni
 ---
 ​
 ## Short description of the project

--- a/_gsocproposals/2025/proposal_SMARTHEP_BEAD.md
+++ b/_gsocproposals/2025/proposal_SMARTHEP_BEAD.md
@@ -9,6 +9,17 @@ organization:
 difficulty: medium
 duration: 350
 mentor_avail: June-August 
+project_mentors:
+  - name: "Pratik Jawahar"
+    email: "pratik.jawahar@cern.ch"
+    organization: "CERN"
+  - name: "Sukanya Sinha"
+    email: "sukanya.sinha@cern.ch"
+    organization: "CERN"
+  - name: "Caterina Doglioni"
+    email: "caterina.doglioni@cern.ch"
+    organization: "CERN"
+    role: "Backup Mentor"
 ---
 ​
 ## Short description of the project
@@ -83,11 +94,6 @@ An improved performance of selected models, with documentation and figures of me
 
    * Desired skills: transformers and/or graph neural networks, particle physics theory and experiments, particle physics simulations
 
-
-## Mentors
-  * ***[Pratik Jawahar](mailto:pratik.jawahar@cern.ch)***
-  * ***[Sukanya Sinha](mailto:sukanya.sinha@cern.ch)***
-  * [Caterina Doglioni](mailto:caterina.doglioni@cern.ch) as backup mentor
 
 ## Links
   * [Paper on unsupervised ML algorithms using HEP datasets](<https://arxiv.org/abs/2105.14027>)

--- a/_gsocproposals/2025/proposal_SMARTHEP_GreenSoftware.md
+++ b/_gsocproposals/2025/proposal_SMARTHEP_GreenSoftware.md
@@ -10,17 +10,20 @@ difficulty: medium
 duration: 350
 mentor_avail: June-October (with 2-3 weeks mentor vacation where student will work independently with minimal guidance)
 project_mentors:
-  - name: "Caterina Doglioni"
-    email: "caterina.doglioni@cern.ch"
-    organization: "CERN"
-  - name: "Tobias Fitschen"
-    email: "tobias.fitschen@cern.ch"
-    organization: "CERN"
-    role: "Backup Mentor"
-  - name: "James Smith"
-    email: "james.smith-7@manchester.ac.uk"
-    organization: "University of Manchester"
-    role: "Backup Mentor"
+  - email: caterina.doglioni@cern.ch
+    organization: CERN
+    first_name: Caterina
+    last_name: Doglioni
+  - email: tobias.fitschen@cern.ch
+    organization: CERN
+    role: Backup Mentor
+    first_name: Tobias
+    last_name: Fitschen
+  - email: james.smith-7@manchester.ac.uk
+    organization: University of Manchester
+    role: Backup Mentor
+    first_name: James
+    last_name: Smith
 ---
 # Description
 

--- a/_gsocproposals/2025/proposal_SMARTHEP_GreenSoftware.md
+++ b/_gsocproposals/2025/proposal_SMARTHEP_GreenSoftware.md
@@ -9,6 +9,18 @@ organization:
 difficulty: medium
 duration: 350
 mentor_avail: June-October (with 2-3 weeks mentor vacation where student will work independently with minimal guidance)
+project_mentors:
+  - name: "Caterina Doglioni"
+    email: "caterina.doglioni@cern.ch"
+    organization: "CERN"
+  - name: "Tobias Fitschen"
+    email: "tobias.fitschen@cern.ch"
+    organization: "CERN"
+    role: "Backup Mentor"
+  - name: "James Smith"
+    email: "james.smith-7@manchester.ac.uk"
+    organization: "University of Manchester"
+    role: "Backup Mentor"
 ---
 # Description
 
@@ -56,12 +68,6 @@ to make it more efficient, and evaluate possible savings.
  * Jupyter notebooks
  * PyTorch or equivalent ML toolkit 
  * Desirable: code profiling experience
-
-## Mentors
-
- * **[Caterina Doglioni](mailto:caterina.doglioni@cern.ch)**
- * **[Tobias Fitschen](mailto:tobias.fitschen@cern.ch)** as backup mentor
- * **[James Smith](mailto:james.smith-7@manchester.ac.uk)** as backup mentor
 
 ## Links
 

--- a/_gsocproposals/2025/proposal_SMARTHEP_GreenSoftware.md
+++ b/_gsocproposals/2025/proposal_SMARTHEP_GreenSoftware.md
@@ -14,14 +14,15 @@ project_mentors:
     organization: CERN
     first_name: Caterina
     last_name: Doglioni
+    is_preferred_contact: yes
   - email: tobias.fitschen@cern.ch
     organization: CERN
-    role: Backup Mentor
+    additional_information: Backup Mentor
     first_name: Tobias
     last_name: Fitschen
   - email: james.smith-7@manchester.ac.uk
     organization: University of Manchester
-    role: Backup Mentor
+    additional_information: Backup Mentor
     first_name: James
     last_name: Smith
 ---

--- a/_gsocproposals/2025/proposal_TMVA-SOFIE-GPU.md
+++ b/_gsocproposals/2025/proposal_TMVA-SOFIE-GPU.md
@@ -12,6 +12,7 @@ project_mentors:
     organization: CERN
     first_name: Lorenzo
     last_name: Moneta
+    is_preferred_contact: yes
   - email: sanjiban.sengupta@cern.ch
     organization: CERN
     first_name: Sanjiban

--- a/_gsocproposals/2025/proposal_TMVA-SOFIE-GPU.md
+++ b/_gsocproposals/2025/proposal_TMVA-SOFIE-GPU.md
@@ -7,6 +7,13 @@ organization: CERN
 difficulty: medium
 duration: 350
 mentor_avail: Flexible
+project_mentors:
+  - name: "Lorenzo Moneta"
+    email: "lorenzo.moneta@cern.ch"
+    organization: "CERN"
+  - name: "Sanjiban Sengupta"
+    email: "sanjiban.sengupta@cern.ch"
+    organization: "CERN"
 ---
 
 # Description
@@ -29,10 +36,6 @@ In this project, the contributor will gain experience with GPU programming and i
   * Proficiency in C++ and Python.
   * Knowledge of GPU programming (e.g., CUDA).
   * Familiarity with version control systems like Git/GitHub.
-
-## Mentors
-  * **[Lorenzo Moneta](mailto:lorenzo.moneta@cern.ch)**
-  * [Sanjiban Sengupta](mailto:sanjiban.sengupta@cern.ch)
 
 ## Links
   * [ROOT Project homepage](https://root.cern/)

--- a/_gsocproposals/2025/proposal_TMVA-SOFIE-GPU.md
+++ b/_gsocproposals/2025/proposal_TMVA-SOFIE-GPU.md
@@ -8,12 +8,14 @@ difficulty: medium
 duration: 350
 mentor_avail: Flexible
 project_mentors:
-  - name: "Lorenzo Moneta"
-    email: "lorenzo.moneta@cern.ch"
-    organization: "CERN"
-  - name: "Sanjiban Sengupta"
-    email: "sanjiban.sengupta@cern.ch"
-    organization: "CERN"
+  - email: lorenzo.moneta@cern.ch
+    organization: CERN
+    first_name: Lorenzo
+    last_name: Moneta
+  - email: sanjiban.sengupta@cern.ch
+    organization: CERN
+    first_name: Sanjiban
+    last_name: Sengupta
 ---
 
 # Description

--- a/_gsocproposals/2025/proposal_TMVA-SOFIE-HLS4ML.md
+++ b/_gsocproposals/2025/proposal_TMVA-SOFIE-HLS4ML.md
@@ -12,6 +12,7 @@ project_mentors:
     organization: CERN
     first_name: Lorenzo
     last_name: Moneta
+    is_preferred_contact: yes
   - email: sanjiban.sengupta@cern.ch
     organization: CERN
     first_name: Sanjiban

--- a/_gsocproposals/2025/proposal_TMVA-SOFIE-HLS4ML.md
+++ b/_gsocproposals/2025/proposal_TMVA-SOFIE-HLS4ML.md
@@ -8,12 +8,14 @@ difficulty: medium
 duration: 350
 mentor_avail: Flexible
 project_mentors:
-  - name: "Lorenzo Moneta"
-    email: "lorenzo.moneta@cern.ch"
-    organization: "CERN"
-  - name: "Sanjiban Sengupta"
-    email: "sanjiban.sengupta@cern.ch"
-    organization: "CERN"
+  - email: lorenzo.moneta@cern.ch
+    organization: CERN
+    first_name: Lorenzo
+    last_name: Moneta
+  - email: sanjiban.sengupta@cern.ch
+    organization: CERN
+    first_name: Sanjiban
+    last_name: Sengupta
 ---
 
 # Description

--- a/_gsocproposals/2025/proposal_TMVA-SOFIE-HLS4ML.md
+++ b/_gsocproposals/2025/proposal_TMVA-SOFIE-HLS4ML.md
@@ -7,6 +7,13 @@ organization: CERN
 difficulty: medium
 duration: 350
 mentor_avail: Flexible
+project_mentors:
+  - name: "Lorenzo Moneta"
+    email: "lorenzo.moneta@cern.ch"
+    organization: "CERN"
+  - name: "Sanjiban Sengupta"
+    email: "sanjiban.sengupta@cern.ch"
+    organization: "CERN"
 ---
 
 # Description
@@ -28,10 +35,6 @@ In this project, the contributor will gain experience with C++ and Python progra
   * Proficiency in C++ and Python.
   * Knowledge of hls4ml
   * Familiarity with version control systems like Git/GitHub.
-
-## Mentors
-  * **[Lorenzo Moneta](mailto:lorenzo.moneta@cern.ch)**
-  * [Sanjiban Sengupta](mailto:sanjiban.sengupta@cern.ch)
 
 ## Links
   * [ROOT Project homepage](https://root.cern/)

--- a/_gsocproposals/2025/proposal_XeusCpp-Debugging.md
+++ b/_gsocproposals/2025/proposal_XeusCpp-Debugging.md
@@ -8,6 +8,19 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Anutosh Bhat"
+    email: "anutosh.bhat@quantstack.net"
+    organization: "QuantStack"
+  - name: "Johan Mabille"
+    email: "johan.mabille@quantstack.net"
+    organization: "QuantStack"
+  - name: "Vipul Cariappa"
+    email: "vipulcariappa@gmail.com"
+    organization: "CompRes"
+  - name: "Aaron Jomy"
+    email: "aaron.jomy@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -24,19 +37,12 @@ However, debugging C++ inside an interactive environment presents unique challen
 * Implement a testing framework through `xeus-zmq` to thoroughly test the debugger. This can be inspired by an existing implementation in `xeus-python`. 
 * Present the work at the relevant meetings and conferences.
 
-
 ## Requirements
 
 * C/C++
 * Basic understanding of the Debug Adapter Protocol
 * Basic understanding of the stack used by xeus-cpp: xeus, cppinterop, clang-repl
 * Research on different DAP implementations like lldb_dap and debuggers like lldb/gdb that can be utilized for the project.
-
-## Mentors
-* **[Anutosh Bhat](mailto:anutosh.bhat@quantstack.net)**
-* [Johan Mabille](mailto:johan.mabille@quantstack.net)
-* [Vipul Cariappa](mailto:vipulcariappa@gmail.com)
-* [Aaron Jomy](mailto:aaron.jomy@cern.ch)
 
 ## Links
 * [Repo](https://github.com/compiler-research/xeus-cpp)

--- a/_gsocproposals/2025/proposal_XeusCpp-Debugging.md
+++ b/_gsocproposals/2025/proposal_XeusCpp-Debugging.md
@@ -9,18 +9,22 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Anutosh Bhat"
-    email: "anutosh.bhat@quantstack.net"
-    organization: "QuantStack"
-  - name: "Johan Mabille"
-    email: "johan.mabille@quantstack.net"
-    organization: "QuantStack"
-  - name: "Vipul Cariappa"
-    email: "vipulcariappa@gmail.com"
-    organization: "CompRes"
-  - name: "Aaron Jomy"
-    email: "aaron.jomy@cern.ch"
-    organization: "CERN"
+  - email: anutosh.bhat@quantstack.net
+    organization: QuantStack
+    first_name: Anutosh
+    last_name: Bhat
+  - email: johan.mabille@quantstack.net
+    organization: QuantStack
+    first_name: Johan
+    last_name: Mabille
+  - email: vipulcariappa@gmail.com
+    organization: CompRes
+    first_name: Vipul
+    last_name: Cariappa
+  - email: aaron.jomy@cern.ch
+    organization: CERN
+    first_name: Aaron
+    last_name: Jomy
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_XeusCpp-Debugging.md
+++ b/_gsocproposals/2025/proposal_XeusCpp-Debugging.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: QuantStack
     first_name: Anutosh
     last_name: Bhat
+    is_preferred_contact: yes
   - email: johan.mabille@quantstack.net
     organization: QuantStack
     first_name: Johan

--- a/_gsocproposals/2025/proposal_XeusCpp-Plugins.md
+++ b/_gsocproposals/2025/proposal_XeusCpp-Plugins.md
@@ -8,6 +8,19 @@ duration: 350
 mentor_avail: June-October
 organization:
   - CompRes
+project_mentors:
+  - name: "Anutosh Bhat"
+    email: "anutosh.bhat@quantstack.net"
+    organization: "QuantStack"
+  - name: "Johan Mabille"
+    email: "johan.mabille@quantstack.net"
+    organization: "QuantStack"
+  - name: "Vipul Cariappa"
+    email: "vipulcariappa@gmail.com"
+    organization: "CompRes"
+  - name: "Aaron Jomy"
+    email: "aaron.jomy@cern.ch"
+    organization: "CERN"
 ---
 
 ## Description
@@ -35,13 +48,6 @@ As an extended goal, we aim to develop a new plugin for GPU execution, leveragin
 * Python
 * C/C++
 * GPU programming; CUDA/OpenMP
-
-
-## Mentors
-* **[Anutosh Bhat](mailto:anutosh.bhat@quantstack.net)**
-* [Johan Mabille](mailto:johan.mabille@quantstack.net)
-* [Vipul Cariappa](mailto:vipulcariappa@gmail.com)
-* [Aaron Jomy](mailto:aaron.jomy@cern.ch)
 
 ## Links
 * [Repo](https://github.com/compiler-research/xeus-cpp)

--- a/_gsocproposals/2025/proposal_XeusCpp-Plugins.md
+++ b/_gsocproposals/2025/proposal_XeusCpp-Plugins.md
@@ -9,18 +9,22 @@ mentor_avail: June-October
 organization:
   - CompRes
 project_mentors:
-  - name: "Anutosh Bhat"
-    email: "anutosh.bhat@quantstack.net"
-    organization: "QuantStack"
-  - name: "Johan Mabille"
-    email: "johan.mabille@quantstack.net"
-    organization: "QuantStack"
-  - name: "Vipul Cariappa"
-    email: "vipulcariappa@gmail.com"
-    organization: "CompRes"
-  - name: "Aaron Jomy"
-    email: "aaron.jomy@cern.ch"
-    organization: "CERN"
+  - email: anutosh.bhat@quantstack.net
+    organization: QuantStack
+    first_name: Anutosh
+    last_name: Bhat
+  - email: johan.mabille@quantstack.net
+    organization: QuantStack
+    first_name: Johan
+    last_name: Mabille
+  - email: vipulcariappa@gmail.com
+    organization: CompRes
+    first_name: Vipul
+    last_name: Cariappa
+  - email: aaron.jomy@cern.ch
+    organization: CERN
+    first_name: Aaron
+    last_name: Jomy
 ---
 
 ## Description

--- a/_gsocproposals/2025/proposal_XeusCpp-Plugins.md
+++ b/_gsocproposals/2025/proposal_XeusCpp-Plugins.md
@@ -13,6 +13,7 @@ project_mentors:
     organization: QuantStack
     first_name: Anutosh
     last_name: Bhat
+    is_preferred_contact: yes
   - email: johan.mabille@quantstack.net
     organization: QuantStack
     first_name: Johan

--- a/_layouts/gsoc_proposal.html
+++ b/_layouts/gsoc_proposal.html
@@ -8,6 +8,21 @@ layout: default
 
   {{ content }}
 
+<h2>Mentors</h2>
+  {% if page.project_mentors %}
+    <ul>
+      {% for mentor in page.project_mentors %}
+      <li>
+        <strong><a href="mailto:{{ mentor.email }}">{{ mentor.name }}</a></strong> - 
+      {% if mentor.role %}{{ mentor.role }} - {% endif %}{{ mentor.organization }}
+      </li>
+      {% endfor %}
+
+    </ul>
+{% else %}
+    <p>No mentors listed.</p>
+{% endif %}
+
 {% if page.year >= 2022 %}
 <h2>Additional Information</h2>
   <ul>

--- a/_layouts/gsoc_proposal.html
+++ b/_layouts/gsoc_proposal.html
@@ -8,14 +8,28 @@ layout: default
 
   {{ content }}
 
+{% if page.year >= 2025 %}
 <h2>Mentors</h2>
   {% if page.project_mentors %}
     <ul>
       {% for mentor in page.project_mentors %}
       <li>
-        <strong><a href="mailto:{{ mentor.email }}">{{ mentor.first_name }} {{ mentor.last_name }} </a></strong>
-      {% if mentor.role %}
-        - {{ mentor.role }} 
+      {% if mentor.is_preferred_contact %}
+        <strong>
+      {% endif %}
+
+      {% if mentor.email %}
+        <a href="mailto:{{ mentor.email }}">
+      {% endif %}
+          {{ mentor.first_name }} {{ mentor.last_name }}
+      {% if mentor.email %}
+        </a>
+      {% endif %}
+      {% if mentor.is_preferred_contact %}
+        </strong>
+      {% endif %}
+      {% if mentor.additional_information %}
+        - {{ mentor.additional_information }} 
       {% endif %}
       {% if mentor.organization %}
        - {{ mentor.organization }}
@@ -26,6 +40,7 @@ layout: default
     </ul>
 {% else %}
     <p>No mentors listed.</p>
+{% endif %}
 {% endif %}
 
 {% if page.year >= 2022 %}

--- a/_layouts/gsoc_proposal.html
+++ b/_layouts/gsoc_proposal.html
@@ -13,8 +13,13 @@ layout: default
     <ul>
       {% for mentor in page.project_mentors %}
       <li>
-        <strong><a href="mailto:{{ mentor.email }}">{{ mentor.name }}</a></strong> - 
-      {% if mentor.role %}{{ mentor.role }} - {% endif %}{{ mentor.organization }}
+        <strong><a href="mailto:{{ mentor.email }}">{{ mentor.first_name }} {{ mentor.last_name }} </a></strong>
+      {% if mentor.role %}
+        - {{ mentor.role }} 
+      {% endif %}
+      {% if mentor.organization %}
+       - {{ mentor.organization }}
+      {% endif %}
       </li>
       {% endfor %}
 

--- a/gsoc/2025/mentors.md
+++ b/gsoc/2025/mentors.md
@@ -3,7 +3,6 @@ title: Summary of Mentors GSoC 2025
 layout: plain
 ---
 
-**Note for contributors:** entries must be sorted in **last name** alphabetic order
 
 {% assign unique_mentors = "" %}
 

--- a/gsoc/2025/mentors.md
+++ b/gsoc/2025/mentors.md
@@ -5,41 +5,48 @@ layout: plain
 
 **Note for contributors:** entries must be sorted in **last name** alphabetic order
 
-## Full Mentor List (Name, Email, Org)
-* Simone Balducci [simone.balducci@cern.ch](mailto:simone.balducci@cern.ch) CERN
-* Martin Barisits [martin.barisits@cern.ch](mailto:martin.barisits@cern.ch) CERN
-* Lukas Breitwieser [lukas.johannes.breitwieser@cern.ch](mailto:lukas.johannes.breitwieser@cern.ch) CERN
-* Anutosh Bhat [anutosh.bhat@quantstack.net](mailto:anutosh.bhat@quantstack.net) QuantStack
-* Andy Buckley [andy.buckley@gla.ac.uk](mailto:andy.buckley@gla.ac.uk) UofGlasgow
-* Vipul Cariappa [vipulcariappa@gmail.com](mailto:vipulcariappa@gmail.com) CompRes
-* Caterina Doglioni [caterina.doglioni@cern.ch](mailto:caterina.doglioni@cern.ch) UManchester
-* Mateusz Fila [mateusz.jakub.fila@cern.ch](mailto:mateusz.jakub.fila@cern.ch) CERN
-* Tobias Fitschen [tobias.fitschen@cern.ch](mailto:tobias.fitschen@cern.ch) UManchester
-* Chris Gutschow [chris.g@cern.ch](mailto:chris.g@cern.ch) UCLondon
-* Pratik Jawahar [pratik.jawahar@postgrad.manchester.ac.uk](mailto:pratik.jawahar@postgrad.manchester.ac.uk) UManchester
-* Aaron Jomy [aaron.jomy@cern.ch](mailto:aaron.jomy@cern.ch) CERN/CompRes
-* Stephan Lachnit [stephan.lachnit@desy.de](mailto:stephan.lachnit@desy.de) DESY
-* David Lange [david.lange@cern.ch](mailto:david.lange@cern.ch) CompRes
-* Serguei Linev [S.Linev@gsi.de](mailto:S.Linev@gsi.de) GSI
-* Johan Mabille [johan.mabille@quantstack.net](mailto:johan.mabille@quantstack.net) QuantStack
-* Ruslan Mashinistov [mashinistov@bnl.gov](mailto:mashinistov@bnl.gov) BNL
-* Peter McKeown [peter.mckeown@cern.ch](mailto:peter.mckeown@cern.ch) CERN
-* Lorenzo Moneta [lorenzo.moneta@cern.ch](mailto:lorenzo.moneta@cern.ch) CERN
-* Felice Pantaleo [felice.pantaleo@cern.ch](mailto:felice.pantaleo@cern.ch) CERN
-* Giacomo Parolini [giacomo.parolini@cern.ch](mailto:giacomo.parolini@cern.ch) CERN
-* Alexander Penev [alexander.p.penev@gmail.com](mailto:alexander.p.penev@gmail.com) CompRes/University of Plovdiv, BG
-* Fons Rademakers [Fons.Rademakers@cern.ch](mailto:Fons.Rademakers@cern.ch) CERN
-* Jonas Rembser[jonas.rembser@cern.ch](mailto:jonas.rembser@cern.ch) CERN
-* Sukanya Sinha [sukanya.sinha@manchester.ac.uk](mailto:sukanya.sinha@manchester.ac.uk) UManchester
-* Sanjiban Sengupta [sanjiban.sengupta@cern.ch](mailto:sanjiban.sengupta@cern.ch) CERN/UManchester
-* James Smith [james.smith-7@manchester.ac.uk](mailto:james.smith-7@manchester.ac.uk) UManchester
-* Mayank Sharma [mayank.sharma@cern.ch](mailto:mayank.sharma@cern.ch) UMich
-* Simon Spannagel [simon.spannagel@desy.de](mailto:simon.spannagel@desy.de) DESY
-* John De Stefano [jd@bnl.gov](mailto:jd@bnl.gov) BNL
-* Graeme Stewart [graeme.andrew.stewart@cern.ch](mailto:graeme.andrew.stewart@cern.ch) CERN
-* Maciej Szymański [maciej.szymanski@cern.ch](mailto:maciej.szymanski@cern.ch) ANL
-* Peter Van Gemmeren [peter.van.gemmeren@cern.ch](mailto:peter.van.gemmeren@cern.ch) ANL
-* Martin Vasilev [mvassilev@uni-plovdiv.bg](mailto:mvassilev@uni-plovdiv.bg) University of Plovdiv, BG
-* Vassil Vassilev [vvasilev@cern.ch](mailto:vvasilev@cern.ch) CompRes
-* Michel Hernandez Villanueva [mhernande1@bnl.gov](mailto:mhernande1@bnl.gov) BNL
-* Valentin Volkl [valentin.volkl@cern.ch](mailto:valentin.volkl@cern.ch) CERN
+{% assign all_mentors = "" %}
+
+<!-- Initialize an empty string to store unique mentors -->
+{% assign unique_mentors = "" %}
+
+<!-- Loop through all pages and collect mentors with unique emails -->
+{% for page in site.gsocproposals %}
+  {% if page.layout == 'gsoc_proposal' and page.year == 2025 and page.project_mentors %}
+    {% for mentor in page.project_mentors %}
+      {% assign mentor_info = mentor.name | append: "," | append: mentor.email | append: "," | append: mentor.organization %}
+
+      {% unless unique_mentors contains mentor.email %}
+        {% assign unique_mentors = unique_mentors | append: mentor_info | append: "|" %}
+      {% endunless %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+
+<!-- Split the mentors into an array -->
+{% assign mentor_array = unique_mentors | split: "|" %}
+
+
+<!-- Create an array of mentor objects with last name as the sorting key -->
+{% assign mentor_objects = "" %}
+{% for mentor in mentor_array %}
+  {% assign mentor_details = mentor | split: "," %}
+  {% assign full_name = mentor_details[0] %}
+  {% assign first_name = full_name | split: " " | first %}
+  {% assign last_name = full_name | split: " " | last %}
+  {% assign mentor_objects = mentor_objects | append: last_name | append: "," | append: first_name | append: "," | append: mentor_details[1] | append: "," | append: mentor_details[2] | append: "|" %}
+{% endfor %}
+
+<!-- Sort mentors by last name -->
+{% assign sorted_mentors = mentor_objects | split: "|" | sort %}
+
+<ul>
+  {% for mentor in sorted_mentors %}
+    {% assign mentor_details = mentor | split: "," %}
+    <li>
+      <strong>{{ mentor_details[0] }} {{ mentor_details[1] }}</strong> 
+      - <a href="mailto:{{ mentor_details[2] }}">{{ mentor_details[2] }}</a> - {{ mentor_details[3] }}
+    </li>
+  {% endfor %}
+</ul>
+

--- a/gsoc/2025/mentors.md
+++ b/gsoc/2025/mentors.md
@@ -5,17 +5,18 @@ layout: plain
 
 **Note for contributors:** entries must be sorted in **last name** alphabetic order
 
-{% assign all_mentors = "" %}
-
-<!-- Initialize an empty string to store unique mentors -->
 {% assign unique_mentors = "" %}
 
 <!-- Loop through all pages and collect mentors with unique emails -->
 {% for page in site.gsocproposals %}
   {% if page.layout == 'gsoc_proposal' and page.year == 2025 and page.project_mentors %}
     {% for mentor in page.project_mentors %}
-      {% assign mentor_info = mentor.name | append: "," | append: mentor.email | append: "," | append: mentor.organization %}
-
+      {% comment %}
+      Build mentor info as:
+      last_name,first_name,email,organization
+      (last_name is first so that sorting works correctly)
+      {% endcomment %}
+      {% assign mentor_info = mentor.last_name | append: "," | append: mentor.first_name | append: "," | append: mentor.email | append: "," | append: mentor.organization %}
       {% unless unique_mentors contains mentor.email %}
         {% assign unique_mentors = unique_mentors | append: mentor_info | append: "|" %}
       {% endunless %}
@@ -23,30 +24,20 @@ layout: plain
   {% endif %}
 {% endfor %}
 
-<!-- Split the mentors into an array -->
+<!-- Split the mentors into an array and sort by last name -->
 {% assign mentor_array = unique_mentors | split: "|" %}
-
-
-<!-- Create an array of mentor objects with last name as the sorting key -->
-{% assign mentor_objects = "" %}
-{% for mentor in mentor_array %}
-  {% assign mentor_details = mentor | split: "," %}
-  {% assign full_name = mentor_details[0] %}
-  {% assign first_name = full_name | split: " " | first %}
-  {% assign last_name = full_name | split: " " | last %}
-  {% assign mentor_objects = mentor_objects | append: last_name | append: "," | append: first_name | append: "," | append: mentor_details[1] | append: "," | append: mentor_details[2] | append: "|" %}
-{% endfor %}
-
-<!-- Sort mentors by last name -->
-{% assign sorted_mentors = mentor_objects | split: "|" | sort %}
+{% assign sorted_mentors = mentor_array | sort %}
 
 <ul>
   {% for mentor in sorted_mentors %}
-    {% assign mentor_details = mentor | split: "," %}
-    <li>
-      <strong>{{ mentor_details[0] }} {{ mentor_details[1] }}</strong> 
-      - <a href="mailto:{{ mentor_details[2] }}">{{ mentor_details[2] }}</a> - {{ mentor_details[3] }}
-    </li>
+    {% if mentor != "" %}
+      {% assign mentor_details = mentor | split: "," %}
+      <li>
+        <strong>{{ mentor_details[1] }} {{ mentor_details[0] }}</strong> 
+        - <a href="mailto:{{ mentor_details[2] }}">{{ mentor_details[2] }}</a> - {{ mentor_details[3] }}
+      </li>
+    {% endif %}
   {% endfor %}
 </ul>
+
 


### PR DESCRIPTION
PR Summary: 
- Mentor names are extracted automatically from the GSoC proposal pages from their front matter "YAML format"
- The mentors are listed uniquely by their email on the mentors page