### PR TITLE
Add missing emails to GEANT4 GSoC proposal

### DIFF
--- a/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
+++ b/_gsocproposals/2025/proposal_Geant4-fastsim_representation.md
@@ -14,10 +14,12 @@ project_mentors:
     first_name: Peter
     last_name: McKeown
     is_preferred_contact: yes
-  - organization: CERN
+  - email: piyush.raikwar@cern.ch
+    organization: CERN
     first_name: Piyush
     last_name: Raikwar
-  - organization: CERN
+  - email: anna.zaborowska@cern.ch
+    organization: CERN
     first_name: Anna
     last_name: Zaborowska
 ---


### PR DESCRIPTION
I noticed missing emails after the PR automating mentor info. I'd like to confirm with @Piyush-555 if the added emails are correct.