### PR TITLE
[gsoc] Fix Clad project title

### DIFF
--- a/_gsocproposals/2025/proposal_Clad-ONNX.md
+++ b/_gsocproposals/2025/proposal_Clad-ONNX.md
@@ -1,5 +1,5 @@
 ---
-title: Enable automatic differentiation of OpenMP programs with Clad
+title: Enable Clad on ONNX-based models
 layout: gsoc_proposal
 project: Clad
 year: 2025


### PR DESCRIPTION
This PR fixes a duplicated title in the clad ONNX project