### PR TITLE
Add pyhep events for 2025.

### DIFF
--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -53,6 +53,8 @@ with the aim to provide an environment to discuss and promote the usage of Pytho
 {:.table .table-hover .table-condensed .table-striped}
 | *Workshop*     | *Location*             | *Date*                | *Agenda link*                                                                         |
 | -------------- | ---------------------- | ----------------------| ------------------------------------------------------------------------------------- |
+| PyHEP 2025     | Online workshop        | October 27-30, 2025   | tba                                                                                   |
+| PyHEP 2025.dev | Seattle, WA, USA       | July 14-17, 2025      | [Indico](https://indico.cern.ch/event/1515852){:target="_pyhep2025_dev_indico"}       |
 | PyHEP 2024.dev | Aachen, Germany        | August 26-30, 2024    | [Indico](https://indico.cern.ch/e/PyHEP2024.dev){:target="_pyhep2024_dev_indico"}     |
 | PyHEP 2024     | Online workshop        | July 1-4, 2024        | [Indico](https://indico.cern.ch/e/PyHEP2024){:target="_pyhep2024_indico"}             |
 | PyHEP 2023     | Online workshop        | October 9-12, 2023    | [Indico](https://indico.cern.ch/e/PyHEP2023){:target="_pyhep2023_indico"}             |
@@ -64,6 +66,35 @@ with the aim to provide an environment to discuss and promote the usage of Pytho
 | PyHEP 2018     | Sofia, Bulgaria        | July 7-8, 2018        | [Indico](https://indico.cern.ch/event/694818/){:target="_pyhep2018_indico"}           |
 
 The advert and details on these workshops are given below.
+
+## PyHEP 2025 & PyHEP.dev 2025
+
+As in previous years, two events will be held again this year:
+
+PyHEP 2025, on October 27-30, is a continuation of the free, online workshop series, which has been bringing
+Python HEP developers and physicists together these past years.
+
+PyHEP.dev 2026 is intended for Python HEP software developers to plan a coherent roadmap and make priorities for the upcoming year. It will be held in-person in Seattle, WA (US) on July 14-17.
+It will include presentations by participants, but the focus will be on birds-of-a-feather style group discussions.
+Attendance is limited to ~50 participants.
+
+### Organising Committee
+
+Matthew Feickert - University of Wisconsin-Madison<br />
+Nikolai Krug - LMU Munich<br />
+Peter Fackeldey - Princeton University<br />
+Ianna Osborne - Princeton University<br />
+Marcel Rieger - Hamburg University<br />
+
+<b>Local organisers:</b><br>
+Gordon Watts - University of Washington
+
+### Sponsors
+
+One of the, or both, events, is/are kindly sponsored by (details on the Indico pages)
+
+![IRIS-HEP]({{ site.baseurl }}/images/pyhep/IRIS-HEP_logo.png){:height="60px"}
+![NSF]({{ site.baseurl }}/images/pyhep/NSF_logo.jpg){:height="60px"}
 
 ## PyHEP 2024 & PyHEP.dev 2024
 

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -94,7 +94,6 @@ Gordon Watts - University of Washington
 One of the, or both, events, is/are kindly sponsored by (details on the Indico pages)
 
 ![IRIS-HEP]({{ site.baseurl }}/images/pyhep/IRIS-HEP_logo.png){:height="60px"}
-![NSF]({{ site.baseurl }}/images/pyhep/NSF_logo.jpg){:height="60px"}
 
 ## PyHEP 2024 & PyHEP.dev 2024
 

--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -54,7 +54,7 @@ with the aim to provide an environment to discuss and promote the usage of Pytho
 | *Workshop*     | *Location*             | *Date*                | *Agenda link*                                                                         |
 | -------------- | ---------------------- | ----------------------| ------------------------------------------------------------------------------------- |
 | PyHEP 2025     | Online workshop        | October 27-30, 2025   | tba                                                                                   |
-| PyHEP 2025.dev | Seattle, WA, USA       | July 14-17, 2025      | [Indico](https://indico.cern.ch/event/1515852){:target="_pyhep2025_dev_indico"}       |
+| PyHEP 2025.dev | Seattle, WA, USA       | July 14-17, 2025      | [Indico](https://indico.cern.ch/e/PyHEP2025.dev){:target="_pyhep2025_dev_indico"}       |
 | PyHEP 2024.dev | Aachen, Germany        | August 26-30, 2024    | [Indico](https://indico.cern.ch/e/PyHEP2024.dev){:target="_pyhep2024_dev_indico"}     |
 | PyHEP 2024     | Online workshop        | July 1-4, 2024        | [Indico](https://indico.cern.ch/e/PyHEP2024){:target="_pyhep2024_indico"}             |
 | PyHEP 2023     | Online workshop        | October 9-12, 2023    | [Indico](https://indico.cern.ch/e/PyHEP2023){:target="_pyhep2023_indico"}             |
@@ -74,7 +74,7 @@ As in previous years, two events will be held again this year:
 PyHEP 2025, on October 27-30, is a continuation of the free, online workshop series, which has been bringing
 Python HEP developers and physicists together these past years.
 
-PyHEP.dev 2026 is intended for Python HEP software developers to plan a coherent roadmap and make priorities for the upcoming year. It will be held in-person in Seattle, WA (US) on July 14-17.
+PyHEP.dev 2025 is intended for Python HEP software developers and power users to plan a coherent roadmap and make priorities for the upcoming year. It will be held in-person in Seattle, WA (US) on July 14-17.
 It will include presentations by participants, but the focus will be on birds-of-a-feather style group discussions.
 Attendance is limited to ~50 participants.
 

--- a/organization/_posts/2025/2025-04-10-coordination.md
+++ b/organization/_posts/2025/2025-04-10-coordination.md
@@ -7,7 +7,7 @@ layout: plain_toc
 
 Present/Contributing: Ruslan Mashinistov, Liz Sexton-Kennedy, Claire Antel, Ianna Osborne, Michel Villanueva, Inês Ochoa, Maarten van Veghel, Juan Miguel Carceller, Sapta Bhattacharya
 
-Apologies/Contributing: Eduardo Rodrigues, Graeme A. Stewart, Paul Laycock, Caterina Doglioni, Michel Jouvin, Christian Wessel, Alexander Moreno Briceño 
+Apologies/Contributing: Eduardo Rodrigues, Graeme A. Stewart, Paul Laycock, Caterina Doglioni, Michel Jouvin, Christian Wessel, Alexander Moreno Briceño
 
 
 ## News, general matters, announcements
@@ -34,7 +34,7 @@ The agenda is available here: <https://indico.cern.ch/event/1484669/timetable/>
 Planned seminars:
 
 - Planning seminar on HS3 (HEP Statistics Serialization Standard) with multiple speakers. Still trying to find suitable date with speakers in April/June - but getting a bit late for April.
-- 28th May (as anounced last time): Seminar on AdePT and Celeritas update on detector simulation with GPUs.
+- 28th May (as announced last time): Seminar on AdePT and Celeritas update on detector simulation with GPUs.
 
 June has a clash with the EPPSU symposium - TBD if we have a seminar.
 
@@ -112,7 +112,7 @@ Future events:
 Ruslan Mashinistov:
 
 - I reached out to people who participated in the GitLab DUO pilot at CERN, as mentioned in the AI-powered development tools at CERN slides, but unfortunately received no responses.
-- Shuwei Ye, an AI tools enthusiast from the BNL NPPS (physics software) group, has agreed to share his experience. He has insights on Aider, DeepSeek-R1, Copilot, Codeium, and more. 
+- Shuwei Ye, an AI tools enthusiast from the BNL NPPS (physics software) group, has agreed to share his experience. He has insights on Aider, DeepSeek-R1, Copilot, Codeium, and more.
 - I need advice on how to attract more presenters and participants for the AI-assisted tools HSF seminar
 
 
@@ -133,7 +133,7 @@ Planning a new meeting with liaisons to discuss contributions.
 [JuliaHEP 2025 Workshop](https://indico.cern.ch/event/1488852/) will be held at Princeton from July 28 to 31.
 - Early registration deadline for local participation: April 25
     - After April 25 an additional fee will apply
-- Final registration deadline: July 7 
+- Final registration deadline: July 7
 
 ### GSoC program 2025
 


### PR DESCRIPTION
This PR adds this years' pyhep events to our activities section.

Texts are similar to that of last year.

We still need to finalize the list of sponsors, draft mode will be dropped once ready.