### PR TITLE
Replace Belle II with CMS.

### DIFF
--- a/_activities/recotrigger.md
+++ b/_activities/recotrigger.md
@@ -28,7 +28,7 @@ of profiling and quality assurance toolkits.
 
 Current WG conveners:
 - Joe Osborn (sPHENIX/ePIC, Brookhaven National Laboratory)
-- Christian Wessel (Belle II, DESY)
+- Christian Wessel (CMS, DESY)
 - Maarten van Veghel (LHCb, Nikhef)
 - Ines Ochoa (ATLAS, LIP)
 


### PR DESCRIPTION
I moved from Belle II to CMS at DESY, though I will still remain a bit active in Belle II for the next few months, but I guess it's OK not to mention Belle II any longer.