### PR TITLE
Added (brief) 2025-07-31-coordination minutes

### DIFF
--- a/organization/_posts/2025/2025-07-31-coordination.md
+++ b/organization/_posts/2025/2025-07-31-coordination.md
@@ -1,5 +1,5 @@
 ---
-title: "HSF Coordination Meeting #292, 17 July 2025"
+title: "HSF Coordination Meeting #293, 31 July 2025"
 layout: plain_toc
 ---
 

--- a/organization/_posts/2025/2025-07-31-coordination.md
+++ b/organization/_posts/2025/2025-07-31-coordination.md
@@ -1,0 +1,28 @@
+---
+title: "HSF Coordination Meeting #292, 17 July 2025"
+layout: plain_toc
+---
+
+## Attending
+
+Present/Contributing: Claire Antel, Caterina Doglioni, Juan Miguel Carceller, Michel Hernandez Villanueva, Torre Wenaus
+
+Apologies/Contributing: N/A
+
+## News, general matters, announcements
+
+Given the low attendance, we decided to cancel this meeting.
+
+CD and CA had a discussion on the Fall seminars and how to co-organise / share the slot with other groups (mainly WLCG environmental sustainability forum and EuCAIF FAIR and sustainable Working Group). 
+
+Conclusion: HSF seminars will mainly take place on the last Wednesday of the month and the Compute & Accelerator Forum on the second Wednesday, so the other groups will avoid these slots. If there is a slot clash, the groups will discuss and in general the HSF seminars will have priority. 
+
+After the August holiday season, Caterina will try to put all seminars in one single category to have a general view of what's going on in a single Indico page. 
+
+### Next Meeting
+
+The next coordination meeting will be 25 September, <https://indico.cern.ch/event/1477087/>, Torre will chair. 
+
+### Chair This Meeting 👇
+
+Please [sign up](https://docs.google.com/spreadsheets/d/1Z1Z4payCpieOLiVFcC6y9j-KCj71u6xX232LHUgIHfI/edit) for chairing a future coordination meeting. (There is even a [HOWTO guide](s://hepsoftwarefoundation.org/organization/running-meetings.html)).


### PR DESCRIPTION
Meeting was cancelled, this contains a record of the discussion that we had on seminar slots after the vacation period. 