### PR TITLE
Add erb gem to fix Ruby 3.4 compatibility 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-
+gem 'erb'
 gem 'tzinfo-data'     # Required for Windows, harmless on other platforms
 gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
Problem #1767

When running (bundle exec jekyll serve) with Ruby 3.4.5 on Arch Linux, Jekyll fails with:

cannot load such file -- erb (LoadError)


## Solution
Added (gem 'erb') to the Gemfile to explicitly declare the dependency.

While erb is a default gem in Ruby 3.4+, explicitly declaring it in the Gemfile ensures Jekyll can properly load it across different Ruby installations and environments.

