### PR TITLE
chore: Remove Matthew and Nikolai from PyHEP activity area conveners

### DIFF
--- a/_activities/pyhep.md
+++ b/_activities/pyhep.md
@@ -12,8 +12,6 @@ the sharing of knowledge and expertise. It embraces the broad community, from HE
 
 * Peter Fackeldey (CMS and IRIS-HEP, Princeton)
 * Ianna Osborne (CMS and IRIS-HEP, Princeton)
-* Matthew Feickert (ATLAS and IRIS-HEP, University of Wisconsin-Madison)
-* Nikolai Krug (Belle II, LMU Munich)
 * Marcel Rieger (CMS, Hamburg University)
 
 All coordinators can be reached at <hsf-pyhep-organisation@googlegroups.com>.
@@ -321,6 +319,8 @@ The event was kindly sponsored by
 
 
 # Previous conveners
+- Nikolai Krug (ATLAS and Belle II, LMU Munich), 2023-2025
+- Matthew Feickert (ATLAS and IRIS-HEP, University of Wisconsin-Madison), 2023-2025
 - Jim Pivarski (CMS and IRIS-HEP, Princeton), 2019-2024
 - Eduardo Rodrigues (LHCb, University of Liverpool), 2018-2024
 - Oksana Shadura (IRIS-HEP, University of Nebraska), 2022-2023


### PR DESCRIPTION
* Matthew stepped down at the end of 2024 to join the Data Analysis activity area and stayed on in an advisory role (but not actively useful) for PyHEP.
   - c.f. https://github.com/HSF/hsf.github.io/pull/1697
* Nikolai has left the field as of September 2025.

cc @pfackeldey @ianna @riga