### PR TITLE
fix: correct end_date in training-schools.yml

### DIFF
--- a/_data/training-schools.yml
+++ b/_data/training-schools.yml
@@ -32,7 +32,7 @@
 - author: Sudhir Malik
   date: 2024-06-05
   deadline: ''
-  end_date: 2023-06-05
+  end_date: 2024-06-05
   source: https://indico.cern.ch/event/1408846/
   tags:
   - HSF


### PR DESCRIPTION
The end_date was incorrectly set to 2023-06-05 for an event starting on 2024-06-05. Changed to 2024-06-05 to match the start date.