### PR TITLE
Fix typos in training documentation

### DIFF
--- a/_data/training-schools.yml
+++ b/_data/training-schools.yml
@@ -77,7 +77,7 @@
   date: 2024-04-15
   deadline: ''
   end_date: 2024-04-19
-  source: hhttps://indico.cern.ch/event/1370034/
+  source: https://indico.cern.ch/event/1370034/
   tags: []
   title: First steps with Geant4
 - author: Sudhir Malik

--- a/howto-website.md
+++ b/howto-website.md
@@ -85,11 +85,11 @@ in there. The [Events](http://hepsoftwarefoundation.org/events.html) page and th
 ### Adding a training event
 
 For *training events* we have a special handling that lists all of these together on the 
-[Training Activity Area page]({{ site.baseurl }}/workinggroups/training.html). To create a new
+[Training Activity Area page]({{ site.baseurl }}/activities/training.html). To create a new
 entry you can either:
 
 1. Run the interactive script ``scripts/add_training_event.py`` (recommended)
-2. Directly edit the ``_data/trainning-schools.yml`` file and add another entry following the structure of the existing entries (note that events are sorted chronologically by starting date)
+2. Directly edit the ``_data/training-schools.yml`` file and add another entry following the structure of the existing entries (note that events are sorted chronologically by starting date)
     - There is one very rare thing you may need to do if the URL for the training event
       will not validate in the link checker, which is to add the tag `url_proof_ignore: true`
       to the YAML file (an example is a school that used a web technology that insists


### PR DESCRIPTION
- Fix hhttps:// to https:// in training-schools.yml (line 80)

- Fix trainning-schools.yml to training-schools.yml in howto-website.md (line 92)

- Fix /workinggroups/training.html to /activities/training.html in howto-website.md (line 88)