### PR TITLE
Update deprecated /workinggroups/ links to /activities/

### DIFF
--- a/_activities-archive/conditionsdb.md
+++ b/_activities-archive/conditionsdb.md
@@ -13,10 +13,10 @@ Discussions between Conditions Database experts across several HEP experiments t
 * Separation of payload queries from metadata queries
 
 Importantly, the group needed to agree on a definition of “conditions data”, concluding that in the context of large scale NHEP computing challenges it is the subset of non-event data used in event-data processing, often using distributed computing resources.  These use cases have strong connections to several other HSF working groups, including 
-[Reconstruction and Software Triggers]({{ site.baseurl}}/workinggroups/recotrigger.html),
-[Detector Simulation]({{ site.baseurl}}/workinggroups/detsim.html),
-[Data Analysis]({{ site.baseurl}}/workinggroups/dataanalysis.html), and
-[Frameworks]({{ site.baseurl}}/workinggroups/frameworks.html).
+[Reconstruction and Software Triggers]({{ site.baseurl}}/activities/recotrigger.html),
+[Detector Simulation]({{ site.baseurl}}/activities/detsim.html),
+[Data Analysis]({{ site.baseurl}}/activities/dataanalysis.html), and
+[Frameworks]({{ site.baseurl}}/activities-archive/frameworks.html).
 Meanwhile, several of those involved in the CWP work continue to discuss solutions around the topics of Conditions Database use cases and functionality.
 
 ----

--- a/_gsocproposals/2023/proposal_HSFTraining_central_entry_point.md
+++ b/_gsocproposals/2023/proposal_HSFTraining_central_entry_point.md
@@ -13,7 +13,7 @@ mentor_avail: May-October
 
 ## Description
 
-There is a large number of training resources for newcomers in the field of High Energy Physics. The [HSF Training group](https://hepsoftwarefoundation.org/workinggroups/training.html) together with [IRIS-HEP](https://iris-hep.org/) has started to compile a curriculum of such training modules that helps to get beginners up to speed quickly. However, the [current listing](https://hepsoftwarefoundation.org/training/curriculum.html) in the form of a static table is quickly becoming overwhelming, and we cannot include many resources because of space limitations.
+There is a large number of training resources for newcomers in the field of High Energy Physics. The [HSF Training group](https://hepsoftwarefoundation.org/activities/training.html) together with [IRIS-HEP](https://iris-hep.org/) has started to compile a curriculum of such training modules that helps to get beginners up to speed quickly. However, the [current listing](https://hepsoftwarefoundation.org/training/curriculum.html) in the form of a static table is quickly becoming overwhelming, and we cannot include many resources because of space limitations.
 This project is about creating a new training center that turns the static page into a dynamic list of training content that can be filtered by attributes such as programming language, common tasks, type of training, HEP experiment, etc. The candidate can start with the code of <https://learn.astropy.org/> (an unrelated training website of a popular astrophysics package) and change the underlying data sources: rather than being based on a series of Jupyter notebooks, configuration files should allow listing arbitrary content.
 
 ## Requirements

--- a/_gsocproposals/2024/proposal_JuliaHEPShowersML.md
+++ b/_gsocproposals/2024/proposal_JuliaHEPShowersML.md
@@ -50,7 +50,7 @@ The evaluation exercise for this project is [here](https://github.com/graeme-a-s
 ## Links
 
 * [Julia Programming Language](https://julialang.org/)
-* [JuliaHEP HSF Group](https://hepsoftwarefoundation.org/workinggroups/juliahep.html)
+* [JuliaHEP HSF Group](https://hepsoftwarefoundation.org/activities/juliahep.html)
 * [Potential of the Julia Programming Language for High Energy Physics Computing](https://doi.org/10.1007/s41781-023-00104-x)
 * [CaloChallenge](https://calochallenge.github.io/homepage/)
 * Some Julia ML toolkits:

--- a/_gsocproposals/2025/proposal_JuliaHepMC3.md
+++ b/_gsocproposals/2025/proposal_JuliaHepMC3.md
@@ -59,7 +59,7 @@ A key outcome would be a set of unit tests and examples, based on the HepMC3 one
 ## Links
 
 - [Julia Programming Language](https://julialang.org/)
-- [JuliaHEP HSF Group](https://hepsoftwarefoundation.org/workinggroups/juliahep.html)
+- [JuliaHEP HSF Group](https://hepsoftwarefoundation.org/activities/juliahep.html)
 - [HepMC3 Repository](https://gitlab.cern.ch/hepmc/HepMC3)
 - [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl)
 - [WrapIt!](https://github.com/grasph/wrapit)

--- a/_training/educators.md
+++ b/_training/educators.md
@@ -3,7 +3,7 @@ title: "Educators"
 layout: plain
 ---
 
-The [HSF training group]({{ site.baseurl }}/workinggroups/training.html) relies on proactive and dedicated educators coming from *within* the field of high energy physics. Here we aim to introduce you to what it means to be an HSF-Educator, the different types of roles that exist, and who has served the community by giving their time and energy to bootstrapping the education of HEP. If you are interested in serving as an educator, please do not hesitate to contact the HSF-Training conveners for more details.
+The [HSF training group]({{ site.baseurl }}/activities/training.html) relies on proactive and dedicated educators coming from *within* the field of high energy physics. Here we aim to introduce you to what it means to be an HSF-Educator, the different types of roles that exist, and who has served the community by giving their time and energy to bootstrapping the education of HEP. If you are interested in serving as an educator, please do not hesitate to contact the HSF-Training conveners for more details.
 
 If you want to organize a complete workshop, we also have [recommendations on that]({{ site.baseurl }}/training/howto-event.html).
 

--- a/jekyll-beginners.md
+++ b/jekyll-beginners.md
@@ -88,7 +88,7 @@ This method can be used to convert a GoogleDoc document to markdown. To do it, u
 Please prefix `{{ site.baseurl }}` in your markdown links, for example
 
 ```
-[link text]({{ site.baseurl}}/workinggroups/dataanalysis.html)
+[link text]({{ site.baseurl}}/activities/dataanalysis.html)
 ```
 {% endraw %}
 

--- a/newsletter/_posts/2019-04-03-Jlab-Workshop.md
+++ b/newsletter/_posts/2019-04-03-Jlab-Workshop.md
@@ -56,20 +56,20 @@ their sessions. Our three new working groups were the stars of the show and
 the quality of the sessions they organised were a testament to how much
 good work and preparation has been done since the start of the year.
 
-[*Detector Simulation*]({{ site.baseurl }}/workinggroups/detsim.html){:target="wg_sim"} looked at
+[*Detector Simulation*]({{ site.baseurl }}/activities/detsim.html){:target="wg_sim"} looked at
 everything from physics improvements for the future to the speed boosts that we
 need and how we can get them. The GeantV vectorisation R&D presented important
 results and the approximate methods for fast simulation were discussed,
 including progress in using machine learning.
 
-[*Data Analysis*]({{ site.baseurl }}/workinggroups/dataanalysis.html){:target="wg_ana"} presented
+[*Data Analysis*]({{ site.baseurl }}/activities/dataanalysis.html){:target="wg_ana"} presented
 a summary of what we learned from their topical workshops, with new approaches
 for the future. Declarative analysis is being explored in many R&Ds now, and
 given the uncertainty in computing architectures for the future, this is a topic
 worth investigating.
 
 [*Reconstruction and Software
-Triggers*]({{ site.baseurl }}/workinggroups/recotrigger.html){:target="wg_reco"} looked at the
+Triggers*]({{ site.baseurl }}/activities/recotrigger.html){:target="wg_reco"} looked at the
 increasing tendency to produce analysis quality output close to the detector,
 both in time and in space, so called *Real Time Analysis*. That touched again on
 integrating compute accelerators, such as FPGAs as a way to do complex inference
@@ -82,13 +82,13 @@ within budget.
 </div>
 
 Many of our other HSF working groups also organised sessions. [*Education and
-Training*]({{ site.baseurl }}/workinggroups/training.html){:target="wg_train"} is still a major
+Training*]({{ site.baseurl }}/activities/training.html){:target="wg_train"} is still a major
 challenge for the community. A survey of what the training needs are for HEP
 provides valuable input for how we organise schools and training in the future.
 The LHCb StarterKit programme continues to shine as an example of bottom-up
 training that is an inspiration for many other experiments.
 
-The [*PyHEP*]({{ site.baseurl }}/workinggroups/pyhep.html){:target="wg_pyhep"} group organised a
+The [*PyHEP*]({{ site.baseurl }}/activities/pyhep.html){:target="wg_pyhep"} group organised a
 session that explored our links with the wider Python community, with an
 emphasis on toolset approaches where different tools mesh together to form the
 required pipeline. There was also a presentation from outside HEP, with Jonathan
@@ -97,9 +97,9 @@ distribution. In the latter our own community has contributed ROOT on Linux and
 OS X platforms, which is already very popular.
 
 The theme of packaging was touched on again in the [*Software Development
-Tools*]({{ site.baseurl }}/workinggroups/softwaredevelopertools.html){:target="wg_swtools"}
+Tools*]({{ site.baseurl }}/activities/toolsandpackaging.html){:target="wg_swtools"}
 session. The [*HSF Packaging
-WG*](https://hepsoftwarefoundation.org/workinggroups/packaging.html){:target="wg_pkg"}
+WG*](https://hepsoftwarefoundation.org/activities/toolsandpackaging.html){:target="wg_pkg"}
 presented solutions that support the wider science community and look like a
 good bet for the future. Closer to the code-face, presentations on profiling and
 static analysis provided developers with good advice about the best tools to


### PR DESCRIPTION
Working groups were renamed to activities. While redirects exist for backward compatibility, updating these links ensures consistency and reduces redirect overhead.

Files updated:

- _activities-archive/conditionsdb.md

- _gsocproposals/2023/proposal_HSFTraining_central_entry_point.md

- _gsocproposals/2024/proposal_JuliaHEPShowersML.md

- _gsocproposals/2025/proposal_JuliaHepMC3.md

- _training/educators.md

- jekyll-beginners.md

- newsletter/_posts/2019-04-03-Jlab-Workshop.md