### PR TITLE
Update GSoC pages from 2024 to 2025 timeline

### DIFF
--- a/_activities/gsoc.md
+++ b/_activities/gsoc.md
@@ -74,11 +74,11 @@ For new HEP-related groups wishing to join HSF GSoC umbrella rather than being i
 <table class="table table-hover table-striped">
   <tr>
     <td> Jan 16 </td>
-    <td> Announcement of GSoC 2024 program in HSF </td>
+    <td> Announcement of GSoC 2025 program in HSF </td>
   </tr>
   <tr>
     <td> Jan 16 </td>
-    <td>Call for 2024 HSF GSoC projects and mentors</td>
+    <td>Call for 2025 HSF GSoC projects and mentors</td>
   </tr>
   <tr>
     <td> Jan 16 - Feb 11 </td>

--- a/gsoc/students-guideline.md
+++ b/gsoc/students-guideline.md
@@ -12,13 +12,13 @@ Get started checking out the [Google Summer of Code Guides for students](https:/
 
 ### How to apply to HSF GSoC
 
-1. Take a look at the list of participating [projects]({{ site.baseurl }}/activities/gsoc.html#projects-in-2024) this year. If there are no projects or just a few, note that more will be added according to this year's [timeline]({{ site.baseurl }}/activities/gsoc.html#timeline).
+1. Take a look at the list of participating [projects]({{ site.baseurl }}/activities/gsoc.html#projects-in-2025) this year. If there are no projects or just a few, note that more will be added according to this year's [timeline]({{ site.baseurl }}/activities/gsoc.html#timeline).
   * There you will find a list of proposals for each project, their descriptions and the contact information of their mentors.
-  * There is also a list with [all the project proposals]({{ site.baseurl }}/gsoc/2024/summary.html) sorted in alphabetical order.
+  * There is also a list with [all the project proposals]({{ site.baseurl }}/gsoc/2025/summary.html) sorted in alphabetical order.
   <!-- Next <br><br>, add an extra new line, otherwise there is no space between point 2 and previous nested bullet  -->
   <br><br>
 
-2. Once you have checked all our proposals and picked the one you like most, please contact the corresponding mentors (their emails can be found at the end of each proposal) sending them your CV and the motivation for picking their proposal. Please do this only after the list of accepted Organizations is published on **Feb 21**, but not after **March 17**, to give time to mentors to evaluate your technical skills. You are encouraged to apply to a maximum of two project proposals.
+2. Once you have checked all our proposals and picked the one you like most, please contact the corresponding mentors (their emails can be found at the end of each proposal) sending them your CV and the motivation for picking their proposal. Please do this only after the list of accepted Organizations is published on **Feb 27**, but not after **March 24**, to give time to mentors to evaluate your technical skills. You are encouraged to apply to a maximum of two project proposals.
 <!-- Next <br><br>, add an extra new line  -->
 <br><br>
 
@@ -29,18 +29,18 @@ Get started checking out the [Google Summer of Code Guides for students](https:/
 
 4. Mentors will announce you by mail if you passed the first stage selection or not, along with potentially other candidates. In case you passed, mentors will usually ask you to write a description for your proposal and help you with the submission. This implies, but is not limited to:
   * Guiding you with the project software (repository, installation, test suite)
-  * Discussing with you the main project objectives and how they can be achieved. This can be done via mail/message/video exchanges, mainly in the period **Mar 18 - Apr 2**.
+  * Discussing with you the main project objectives and how they can be achieved. This can be done via mail/message/video exchanges, mainly in the period **Mar 24 - Apr 8**.
   * Giving you pointers to documentation material and/or asking you to find references helping you make your proposal.
 <br><br>
 
 5. You will have to write a proposal that must contain:
   * A detailed plan of work with a timeline spanning over **90 or 175 or 375 hours**, which is the GSoC coding period duration this year. Note that your availability for working on the project has to be clearly stated (agreed upon with your mentors) and represents an engagement on your side. Breaking it during the coding period without prior notice and mentor's agreement represents a reason for being failed.
   * Well defined tasks and their objectives, with a list of deliverables upon which the success of the project will be determined.
-  * Between **Mar 18 - Mar 26** you will have the possibility to share your proposal draft with the project mentors to get improvement suggestions, before making your GSoC application due on **Apr 2**.
+  * Between **Mar 30 - Apr 8** you will have the possibility to share your proposal draft with the project mentors to get improvement suggestions, before making your GSoC application due on **Apr 8**.
   * Make sure to submit the proposal through the GSoC dashboard, not only to mentors.
 <br><br>
 
-6. Your proposal will be evaluated and ranked by your mentors, who give their feedback to the HSF Org Admins. If a project has eligible candidates, it will be considered for the request of slots made to GSoC, due on **Apr 20**. Note that the result of this Phase 2 selection process cannot be made available before the official announcement by Google of the successful student projects, on **May 1**.
+6. Your proposal will be evaluated and ranked by your mentors, who give their feedback to the HSF Org Admins. If a project has eligible candidates, it will be considered for the request of slots made to GSoC, due on **Apr 20**. Note that the result of this Phase 2 selection process cannot be made available before the official announcement by Google of the successful student projects, on **May 8**.
 
 We do not provide a mailing list for candidates, but there is a chat room in [![Gitter](https://badges.gitter.im/HSF/HSF-GSoC.svg)](https://gitter.im/HSF/HSF-GSoC?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) where you can ask questions, getting answers from the HSF Admins and previous students in our Organization. Please avoid posting extended information about yourself in the chat channel and reserve this for the first exchange with the mentors. 
 


### PR DESCRIPTION
Fix outdated year references and dates in GSoC documentation:

- _activities/gsoc.md: Update timeline table from 2024 to 2025

- gsoc/students-guideline.md: Update project links from 2024 to 2025

- gsoc/students-guideline.md: Update dates to match 2025 timeline