### PR TITLE
Add HSF history paper

### DIFF
--- a/organization/documents.md
+++ b/organization/documents.md
@@ -16,6 +16,7 @@ a full list of all of the papers connected to the [Community White Paper]({{ sit
 | Analysis Facilities White Paper | Community Analysis Facilities discussions | [arXiv](https://arxiv.org/abs/2404.02100) | HSF-TN-2024-01 |
 | Second Analysis Ecosystem Workshop Report | HSF IRIS-HEP Second Analysis Ecosystem Workshop | [arXiv](https://arxiv.org/abs/2212.04889), [Zenodo](https://doi.org/10.5281/zenodo.7003962) | [LaTeX](https://github.com/HSF/documents/tree/master/HSF-DOC/2022-02) |
 | Constraints on future analysis metadata systems in High Energy Physics | | [ Comput Softw Big Sci (2022) 6, 13](https://doi.org/10.1007/s41781-022-00086-2) | |
+| The HEP Software Foundation Community | A History of the HSF | [arXiv](https://arxiv.org/abs/2205.08193) | [GitHub](https://github.com/HSF/documents/tree/master/HSF-DOC/2022-01) |
 | HL-LHC Computing Review Stage 2, Common Software Projects: Data Science Tools for Analysis | LHCC review of HL-LHC Computing | [arXiv](https://arxiv.org/abs/2202.02194) | |
 | HL-LHC Computing Review: Common Tools and Community Software | May 2020 LHCC HL-LHC review and US Snowmass Process | [Zenodo](https://zenodo.org/record/4009114) | [LaTeX](https://github.com/HSF/documents/tree/master/LHCC/2020/2020-01) |
 | Monte Carlo generators challenges and strategy towards HL-LHC | May 2020 LHCC HL-LHC review and US Snowmass Process | [arXiv](https://arxiv.org/abs/2004.13687) | |

--- a/organization/goals.md
+++ b/organization/goals.md
@@ -36,4 +36,7 @@ by ALICE, ATLAS, Belle II, CMS, DUNE, ePIC, LHCb, MCnet and WLCG.
 The [HSF Steering Group]({{ site.baseurl }}/organization/team.html) helps to run the
 organisation on a day to day basis.
 
+You can read more about the history of the HSF in our paper on [The HEP
+Software Foundation Community](https://arxiv.org/abs/2205.08193).
+
 Please feel free to ask us any questions you have.


### PR DESCRIPTION
The HSF history paper was missing from the website. It is added to the list of documents and referenced in the "goals" page now.