### PR TITLE
gsoc: add gsocorgs for 2026

### DIFF
--- a/_gsocorgs/2026/cern.md
+++ b/_gsocorgs/2026/cern.md
@@ -1,0 +1,11 @@
+---
+title: "CERN"
+author: "Benedikt Hegner"
+layout: default
+organization: CERN
+logo: CERN-logo.jpg
+description: |
+  At [CERN](https://home.cern), the European Organization for Nuclear Research, physicists and engineers are probing the fundamental structure of the universe. They use the world's largest and most complex scientific instruments to study the basic constituents of matter – the fundamental particles.
+---
+
+{% include gsoc_proposal.ext %}


### PR DESCRIPTION
Forgot to copy the cern gsocorgs file in #1804 