### PR TITLE
Patch for case and max width

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -64,7 +64,7 @@ layout: default
           <h2>GSoC 2026</h2>
           <p>Once again the HSF will participate as an umbrella organisation as part of the <a href="https://summerofcode.withgoogle.com">Google Summer of Code</a>.
           <p style="display: block; text-align: center">
-            <img src="{{ '/images/GSoC/GSoc-icon-192.png' | relative_url }}" alt="GSoC Logo" style="width:60%; margin-left: auto; margin-right: auto;">
+            <img src="{{ '/images/GSoC/GSoC-icon-192.png' | relative_url }}" alt="GSoC Logo" style="max-width: 250px; width:60%; margin-left: auto; margin-right: auto;">
           </p>
           <p>Please take a look at our organisation's <a href="{{ '/activities/gsoc.html' | relative_url }}">GSoC Pages</a> for details on how to apply for HSF projects.</p>    
         </div>


### PR DESCRIPTION
There was a case mistake in the merged centre column patch (#1821), this fixes that (this was not evident on OS X, which is a case insensitive filesystem!).

Also, limit the maximum image size of the GSoC logo to 250px (helps on medium screen sizes).