### PR TITLE
feat: insert CppCon link to PODIO GSoC proposal

### DIFF
--- a/_gsocproposals/2026/proposal_PODIO_Arrow.md
+++ b/_gsocproposals/2026/proposal_PODIO_Arrow.md
@@ -60,3 +60,4 @@ Once CERN/HSF is accepted as a GSoC org, please write an email with a short intr
 
  - [Apache Arrow](https://arrow.apache.org/)
  - [PODIO](https://github.com/AIDASoft/podio)
+ - [C++’s Next Decade - Herb Sutter - CppCon 2024](https://www.youtube.com/watch?v=FNi1-x4pojs&t=3720s)


### PR DESCRIPTION
Addressing suggestion https://github.com/HSF/hsf.github.io/pull/1832#pullrequestreview-3735279115. This is probably irrelevant to the proposal, but I'm happy to include, if people agree that it may be of interest to participants.