### PR TITLE
gsoc26: add proposal for sofie-alpaka implementation

### DIFF
--- a/_gsocproposals/2026/proposal_ML4EP_SOFIE_ALPAKA.md
+++ b/_gsocproposals/2026/proposal_ML4EP_SOFIE_ALPAKA.md
@@ -14,7 +14,8 @@ project_mentors:
     last_name: Sengupta
     organization: CERN
     is_preferred_contact: yes
-  - first_name: Lorenzo
+  - email: lorenzo.moneta@cern.ch
+    first_name: Lorenzo
     last_name: Moneta
     organization: CERN
 ---


### PR DESCRIPTION
This PR adds a proposal for GSoC 2026 on the SOFIE-alpaka implementation under the ML4EP project of CERN.