### PR TITLE
gsoc26: Add repository links and license metadata to projects ( #1862 ) 

### DIFF
--- a/_gsocproposals/2026/proposal_NegativeWeightsMCFM.md
+++ b/_gsocproposals/2026/proposal_NegativeWeightsMCFM.md
@@ -54,3 +54,9 @@ Release a modified version of MCFM that successfully incorporates the negative w
 
 AI assistance is allowed for this contribution. The applicant takes full responsibility for all code and results, disclosing AI use for non-routine tasks (algorithm design, architecture, complex problem-solving). Routine tasks (grammar, formatting, style) do not require disclosure.
 
+
+## Links
+
+ * [Repo](https://gitlab.com/mcfm-team)
+ * [MCFM](https://mcfm.fnal.gov/) 
+


### PR DESCRIPTION
Adding links to the https://github.com/HSF/hsf.github.io/blob/main/_gsocprojects/2026/ for repositories and licenses ;