### PR TITLE
gsoc26: Add repository and license metadata to ATLAS project

### DIFF
--- a/_gsocprojects/2026/project_ATLAS.md
+++ b/_gsocprojects/2026/project_ATLAS.md
@@ -2,6 +2,8 @@
 project: ATLAS
 layout: default
 logo: ATLAS-logo.png
+repository: https://gitlab.cern.ch/atlas
+license: GPL-3.0
 description: |
   [ATLAS](http://atlas.cern) is one of the four major experiments at the [Large Hadron Collider](http://home.web.cern.ch/topics/large-hadron-collider) (LHC) at [CERN](http://home.cern/). It is a general-purpose particle physics experiment run by an international collaboration and is designed to exploit the full discovery potential and the huge range of physics opportunities that the LHC provides.
 ---


### PR DESCRIPTION
Added repository and license metadata for ATLAS project under _gsocprojects/2026/.

Submitting this as a reference implementation before updating the remaining 2026 projects.

Fixes #1862