### PR TITLE
Fix typo in title from 'Aparche' to 'Apache'

### DIFF
--- a/_gsocproposals/2026/proposal_PODIO_Arrow.md
+++ b/_gsocproposals/2026/proposal_PODIO_Arrow.md
@@ -1,5 +1,5 @@
 ---
-title: Aparche Arrow interface for PODIO
+title: Apache Arrow interface for PODIO
 layout: gsoc_proposal
 project: PODIO
 year: 2026


### PR DESCRIPTION
Commit title thanks to copilot