### PR TITLE
gsoc26: add repository and license metadata for Spack

### DIFF
--- a/_gsocprojects/2026/project_Spack.md
+++ b/_gsocprojects/2026/project_Spack.md
@@ -2,6 +2,8 @@
 project: Spack
 layout: default
 logo: spack-logo-220-LLNL.png
+repository: https://github.com/spack/spack
+license: Apache-2.0
 description: |
   [Spack](https://spack.io) is a flexible package manager designed to support multiple versions, configurations, platforms, and compilers. It is widely used in high-performance computing (HPC) environments to manage complex software stacks.
 ---


### PR DESCRIPTION
﻿## Description
* Added the missing `repository` field for the project metadata.
* Added the standard SPDX-style `license` field.

## Context
This follows the format discussed in #1862 and mirrors the metadata style used in prior related PRs.

Closes #1862
