### PR TITLE
gsoc26: add repository and license metadata for NNPDF

### DIFF
--- a/_gsocprojects/2026/project_NNPDF.md
+++ b/_gsocprojects/2026/project_NNPDF.md
@@ -3,6 +3,8 @@ title: NNPDF
 project: NNPDF
 layout: default
 logo: nnpdf.png
+repository: https://github.com/NNPDF/nnpdf
+license: GPL-3.0
 description: |
   The [NNPDF collaboration](https://nnpdf.mi.infn.it/) determines the structure of the proton using contemporary methods of artificial intelligence. A precise knowledge of the so-called Parton Distribution Functions (PDFs) of the proton, which describe their structure in terms of their quark and gluon constituents, is a crucial ingredient of the physics program of the Large Hadron Collider of CERN. The NNPDF projects includes tools for DGLAP evolution: [EKO](https://eko.readthedocs.io), grid interpolation: [PineAPPL](https://nnpdf.github.io/pineappl/), and the fitting framework [nnpdf](https://docs.nnpdf.science)
 ---


### PR DESCRIPTION
﻿## Description
* Added the missing `repository` field for the project metadata.
* Added the standard SPDX-style `license` field.

## Context
This follows the format discussed in #1862 and mirrors the metadata style used in prior related PRs.

Closes #1862
