### PR TITLE
gsoc26: add repository and license metadata for CMS

### DIFF
--- a/_gsocprojects/2026/project_CMS.md
+++ b/_gsocprojects/2026/project_CMS.md
@@ -2,6 +2,8 @@
 project: CMS
 layout: default
 logo: CMS-logo.png
+repository: https://github.com/cms-sw/cmssw
+license: Apache-2.0
 description: |
    [CMS](http://cms.cern/) is a high-energy physics experiment at the [Large Hadron Collider](http://home.web.cern.ch/topics/large-hadron-collider) (LHC) at [CERN](http://home.cern/).  It is a general-purpose detector that is designed to observe any new physics phenomena that the LHC might reveal. CMS acts as a giant, high-speed camera, taking 3D "photographs" of particle collisions from all directions up to 40 million times each second. The CMS collects few tens of Peta-Bytes of data each year and processes them through Worldwide LHC Computing Grid infrastructure around the globe.
 ---


### PR DESCRIPTION
﻿## Description
* Added the missing `repository` field for the project metadata.
* Added the standard SPDX-style `license` field.

## Context
This follows the format discussed in #1862 and mirrors the metadata style used in prior related PRs.

Closes #1862
