### PR TITLE
gsoc26: add repository and license metadata for Clad

### DIFF
--- a/_gsocprojects/2026/project_Clad.md
+++ b/_gsocprojects/2026/project_Clad.md
@@ -2,6 +2,8 @@
 project: Clad
 layout: default
 logo: Clad-logo.png
+repository: https://github.com/vgvassilev/clad
+license: LGPL-3.0
 description: |
   [Clad](https://clad.readthedocs.io/en/latest/) enables 
   automatic differentiation (AD) for C++. It is based on LLVM compiler 


### PR DESCRIPTION
﻿## Description
* Added the missing `repository` field for the project metadata.
* Added the standard SPDX-style `license` field.

## Context
This follows the format discussed in #1862 and mirrors the metadata style used in prior related PRs.

Closes #1862
