### PR TITLE
gsoc26: add repository and license metadata for FCC

### DIFF
--- a/_gsocprojects/2026/project_FCC.md
+++ b/_gsocprojects/2026/project_FCC.md
@@ -3,6 +3,8 @@ title: Future Circular Collider
 project: FCC
 layout: default
 logo: fcc-logo.png
+repository: https://github.com/HEP-FCC/FCCAnalyses
+license: Apache-2.0
 description: |
   The [Future Circular Collider](https://fcc.cern/) (FCC) is a proposed
   next-generation particle accelerator at CERN for the post High Luminosity


### PR DESCRIPTION
﻿## Description
* Added the missing `repository` field for the project metadata.
* Added the standard SPDX-style `license` field.

## Context
This follows the format discussed in #1862 and mirrors the metadata style used in prior related PRs.

Closes #1862
