### PR TITLE
gsoc26: add repository and license metadata for Key4hep

### DIFF
--- a/_gsocprojects/2026/project_Key4hep.md
+++ b/_gsocprojects/2026/project_Key4hep.md
@@ -3,6 +3,8 @@ title: Key4hep
 project: Key4hep
 layout: default
 logo: key4hep-logo.png
+repository: https://github.com/key4hep/EDM4hep
+license: Apache-2.0
 description: >
   The [Key4hep](https://cern.ch/key4hep/) project provides an
   experiment-independent, turnkey software stack for future colliders such as


### PR DESCRIPTION
﻿## Description
* Added the missing `repository` field for the project metadata.
* Added the standard SPDX-style `license` field.

## Context
This follows the format discussed in #1862 and mirrors the metadata style used in prior related PRs.

Closes #1862
