### PR TITLE
gsoc26: add repository and license metadata for CernVM-FS

### DIFF
--- a/_gsocprojects/2026/project_CernVM-FS.md
+++ b/_gsocprojects/2026/project_CernVM-FS.md
@@ -3,6 +3,8 @@ title: CernVM-FS
 project: CernVM-FS
 layout: default
 logo: cernvmfs-logo.png
+repository: https://github.com/cvmfs/cvmfs
+license: BSD-3-Clause
 description: |
   The CernVM-File System ([CVMFS](https://cernvm.cern.ch/fs/)) is a global, read-only POSIX filesystem that provides the universal namespace /cvmfs. It is based on content-addressable storage, Merkle trees, and HTTP data transport.  CernVM-FS provides a mission critical infrastructure to small and large HEP collaborations.
 ---


### PR DESCRIPTION
﻿## Description
* Added the missing `repository` field for the project metadata.
* Added the standard SPDX-style `license` field.

## Context
This follows the format discussed in #1862 and mirrors the metadata style used in prior related PRs.

Closes #1862
