### PR TITLE
Add info on AG chair and secretary

### DIFF
--- a/organization/advisory-group.md
+++ b/organization/advisory-group.md
@@ -40,3 +40,9 @@ A nominal meeting schedule consists of one AG meeting per year, arranged to prec
 ## Advisory Group Chair Election
 
 The Advisory Group chair is elected annually and serves for 2 years, serving a maximum of 2 terms. The Steering Group secretary serves as returning officer and is in charge of running the election. Candidates for the chair of the Advisory Group can be nominated and can self-nominate. The election will be held by confidential ballot. In the case of a tie, with more than two candidates, the top two candidates are retained and a second round is held. If there is still a tie after the second round, the AG chair is decided by lot.
+
+## Present and Past AG Chairs
+
+## Present and Past Secretaries / Returning Officers
+
+* Paul Laycock (Einstein Telescope, University of Geneva), 01/2025 -

--- a/organization/advisory-group.md
+++ b/organization/advisory-group.md
@@ -1,6 +1,6 @@
 ---
 title: HSF Advisory Group
-author: Graeme Stewart
+author: Graeme Stewart, Eduardo Rodrigues
 layout: default
 ---
 
@@ -43,6 +43,8 @@ The Advisory Group chair is elected annually and serves for 2 years, serving a m
 
 ## Present and Past AG Chairs
 
+- Christian Gutschow (University College London), 05/2026 -
+
 ## Present and Past Secretaries / Returning Officers
 
-* Paul Laycock (Einstein Telescope, University of Geneva), 01/2025 -
+- Paul Laycock (Einstein Telescope, University of Geneva), 01/2025 -


### PR DESCRIPTION
Same as for the SG page, it makes sense to add info on the history of AG chairs and returning officers.

(This is draft since the conclusion of the election of our AG chair is due within a few days, at which point I will merge this. Approval on the content idea is already welcome, of course.)