### PR TITLE
add pyhep dev 2026 announcement

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -59,12 +59,12 @@ layout: default
       </div>
       
       <div class="col-lg-4">
-        <h2>GSoC 2026</h2>
-        <p>Once again the HSF will participate as an umbrella organisation as part of the <a href="https://summerofcode.withgoogle.com">Google Summer of Code</a>.</p>
+        <h2>PyHEP.dev 2026</h2>
+        <p>Announcement of <a href="https://indico.nikhef.nl/event/7873/">PyHEP.dev 2026</a>!</p>
         <p style="display: block; text-align: center">
-          <img src="{{ '/images/GSoC/GSoC-icon-192.png' | relative_url }}" alt="GSoC Logo" style="max-width: 250px; width:60%; margin-left: auto; margin-right: auto;">
+          <img src="{{ '/images/pyhep/PyHEP_logo.svg' | relative_url }}" alt="PyHEP Logo" style="max-width: 250px; width:60%; margin-left: auto; margin-right: auto;">
         </p>
-        <p>Please take a look at our organisation's <a href="{{ '/activities/gsoc.html' | relative_url }}">GSoC Pages</a> for details on how to apply for HSF projects.</p>    
+        <p>Please register if you're interested <a href="https://indico.nikhef.nl/event/7873/registrations/979/">here</a>.</p>
       </div>
       
       <div class="col-lg-4">

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -64,7 +64,7 @@ layout: default
         <p style="display: block; text-align: center">
           <img src="{{ '/images/pyhep/PyHEP_logo.svg' | relative_url }}" alt="PyHEP Logo" style="max-width: 250px; width:60%; margin-left: auto; margin-right: auto;">
         </p>
-        <p>Please register if you're interested <a href="https://indico.nikhef.nl/event/7873/registrations/979/">here</a>.</p>
+        <p>Feel encouraged to register <a href="https://indico.nikhef.nl/event/7873/registrations/979/">here</a>!</p>
       </div>
       
       <div class="col-lg-4">

--- a/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
+++ b/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
@@ -1,0 +1,19 @@
+---
+title: PyHEP.dev 2026 Workshop, September 7-9, 2026
+author: Peter Fackeldey
+layout: newsletter
+symbol: glyphicon-calendar
+link: https://indico.nikhef.nl/event/7873/
+until: 2026-09-12
+---
+We are happy to announce PyHEP.dev 2026 Developers Workshop in Amsterdam (Nikhef), September 9-11, 2026: https://indico.nikhef.nl/event/7873/.
+
+You are warmly invited to submit your abstracts to: https://indico.nikhef.nl/event/7873/abstracts/.
+
+The key topics of this PyHEP.dev workshop will be:
+- Agentic SWE and Tooling
+- Distributed Computing and Workflows
+- Data Analysis Tools, e.g., I/O, Histogramming, Statistical Tools, Visualization
+- Packaging & Distribution
+
+We very much look forward to seeing you in Amsterdam in September!

--- a/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
+++ b/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
@@ -6,7 +6,7 @@ symbol: glyphicon-calendar
 link: https://indico.nikhef.nl/event/7873/
 until: 2026-09-12
 ---
-We are happy to announce the PyHEP.dev 2026 Developers Workshop that will be held in Amsterdam (Nikhef) on September 9-11, 2026: https://indico.nikhef.nl/event/7873/.
+We are happy to announce the PyHEP.dev 2026 Developers Workshop that will be held in Amsterdam (Nikhef) on September 7-9, 2026: https://indico.nikhef.nl/event/7873/.
 
 You are warmly invited to submit your abstracts to https://indico.nikhef.nl/event/7873/abstracts/.
 

--- a/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
+++ b/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
@@ -6,7 +6,7 @@ symbol: glyphicon-calendar
 link: https://indico.nikhef.nl/event/7873/
 until: 2026-09-12
 ---
-We are happy to announce PyHEP.dev 2026 Developers Workshop in Amsterdam (Nikhef), September 9-11, 2026: https://indico.nikhef.nl/event/7873/.
+We are happy to announce the PyHEP.dev 2026 Developers Workshop that will be held in Amsterdam (Nikhef) on September 9-11, 2026: https://indico.nikhef.nl/event/7873/.
 
 You are warmly invited to submit your abstracts to: https://indico.nikhef.nl/event/7873/abstracts/.
 

--- a/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
+++ b/announcements/_posts/2026/2026-07-07-PyHEPdev2026.md
@@ -8,7 +8,7 @@ until: 2026-09-12
 ---
 We are happy to announce the PyHEP.dev 2026 Developers Workshop that will be held in Amsterdam (Nikhef) on September 9-11, 2026: https://indico.nikhef.nl/event/7873/.
 
-You are warmly invited to submit your abstracts to: https://indico.nikhef.nl/event/7873/abstracts/.
+You are warmly invited to submit your abstracts to https://indico.nikhef.nl/event/7873/abstracts/.
 
 The key topics of this PyHEP.dev workshop will be:
 - Agentic SWE and Tooling

--- a/events/_posts/2026-07-07-PyHEPdev2026.md
+++ b/events/_posts/2026-07-07-PyHEPdev2026.md
@@ -1,5 +1,5 @@
 ---
-title: PyHEP.dev 2026 "Python in HEP" Workshop, Amsterdam/Nikhef, September 7-9, 2026
+title: PyHEP.dev 2026 "Python in HEP" Developers Workshop, Amsterdam/Nikhef, September 7-9, 2026
 author: Peter Fackeldey
 layout: event
 startdate: 2026-09-07

--- a/events/_posts/2026-07-07-PyHEPdev2026.md
+++ b/events/_posts/2026-07-07-PyHEPdev2026.md
@@ -20,6 +20,6 @@ The key topics of this PyHEP.dev workshop will be:
 - Data Analysis Tools, e.g., I/O, Histogramming, Statistical Tools, Visualization
 - Packaging & Distribution
 
-You are warmly invited to submit _your_ abstracts to: https://indico.nikhef.nl/event/7873/abstracts/.
+You are warmly invited to submit _your_ abstracts to https://indico.nikhef.nl/event/7873/abstracts/.
 
 We very much look forward to seeing you in Amsterdam in September!

--- a/events/_posts/2026-07-07-PyHEPdev2026.md
+++ b/events/_posts/2026-07-07-PyHEPdev2026.md
@@ -1,0 +1,25 @@
+---
+title: PyHEP.dev 2026 "Python in HEP" Workshop, Amsterdam/Nikhef, September 7-9, 2026
+author: Peter Fackeldey
+layout: event
+startdate: 2026-09-07
+---
+We are happy to announce the **PyHEP.dev 2026 Developers Workshop** that will be held in Amsterdam (Nikhef) on September 9-11, 2026: https://indico.nikhef.nl/event/7873/.
+
+The workshop will be a forum for the participants and the community at large
+to discuss developments of Python packages and tools, exchange experiences,
+and steer where the community needs and wants to go.
+There will be ample time for discussions and hackathons.
+
+_New:_ at this year’s PyHEP.dev workshop specific time will be set aside for agent-based 
+software development and the associated tools.
+
+The key topics of this PyHEP.dev workshop will be:
+- Agentic SWE and Tooling
+- Distributed Computing and Workflows
+- Data Analysis Tools, e.g., I/O, Histogramming, Statistical Tools, Visualization
+- Packaging & Distribution
+
+You are warmly invited to submit _your_ abstracts to: https://indico.nikhef.nl/event/7873/abstracts/.
+
+We very much look forward to seeing you in Amsterdam in September!


### PR DESCRIPTION
Adding a post about PyHEP dev 2026 announcement, and replacing GSoC on the fronpage with PyHEP dev 2026 as proposed by @eduardo-rodrigues.

(let's see if it renders nicely :) )