### PR TITLE
Be consistent with the word convener

### DIFF
--- a/_activities-archive/visualization.md
+++ b/_activities-archive/visualization.md
@@ -16,7 +16,7 @@ All are welcome to join the group and participate!
 
 ## Contacts
 
-Convenor: [Riccardo Maria BIANCHI](mailto:riccardo.maria.bianchi@cern.ch) (ATLAS)
+Convener: [Riccardo Maria BIANCHI](mailto:riccardo.maria.bianchi@cern.ch) (ATLAS)
 
 Mailing list: [hsf-visualization-wg@googlegroups.com](mailto:hsf-visualization-wg@googlegroups.com)
 

--- a/_activities/dataanalysis.md
+++ b/_activities/dataanalysis.md
@@ -33,9 +33,9 @@ well-defined set of problems.
 - Luke Kreczko, CMS/LZ and University of Bristol
 - Nick Smith, CMS and Fermilab
 
-Contact the [convenors by email](mailto:matthew.feickert@cern.ch,jamie.gooding@cern.ch,kreczko@cern.ch,nick.smith@cern.ch) <!-- markdown-link-check-disable-line -->
+Contact the [conveners by email](mailto:matthew.feickert@cern.ch,jamie.gooding@cern.ch,kreczko@cern.ch,nick.smith@cern.ch) <!-- markdown-link-check-disable-line -->
 
-### Former Convenors
+### Former Conveners
 
 - Alexander Held (ATLAS), 2023-2024
 - Nicole Skidmore (LHCb), 2021-2023

--- a/_activities/generators.md
+++ b/_activities/generators.md
@@ -60,18 +60,18 @@ HSF meeting [report]({{ site.baseurl }}/organization/2018/12/13/coordination.htm
 (latest sources and pdf from 11 November 2017 archived
 on [HSF/documents](https://github.com/HSF/documents/tree/master/CWP/papers/HSF-CWP-2017-11_generators))
 
-## Convenors
+## Conveners
 
-#### Current convenors
+#### Current conveners
 
 - Saptaparna Bhattacharya, CMS and Wayne State University (2024-)
 - Steven Gardiner, DUNE and Fermilab (2024-)
 - Joshua Isaacson, theory and Michigan State University (2026-)
 - Stephen Mrenna, CMS and Fermilab (2024-)
 
-All convenors can be reached [by email](mailto:hsf-generator-wg-convenors@googlegroups.com). <!-- markdown-link-check-disable-line -->
+All conveners can be reached [by email](mailto:hsf-generator-wg-convenors@googlegroups.com). <!-- markdown-link-check-disable-line -->
 
-#### Former convenors
+#### Former conveners
 
 - Stefan Hoeche (2018-2019)
 - Steve Mrenna (2018-2019)

--- a/_includes/list_of_selected_profiles.html
+++ b/_includes/list_of_selected_profiles.html
@@ -1,5 +1,5 @@
 <!-- If the persons array is set, this will only include profiles of those
-people who are in the persons array. This can be used to include the convenors 
+people who are in the persons array. This can be used to include the conveners
 for example.-->
 
 {% include profile_header.html %}

--- a/_profiles/meirin_oan_evans.md
+++ b/_profiles/meirin_oan_evans.md
@@ -19,4 +19,4 @@ email: meirin.oan.evans@cern.ch
 layout: educator
 ---
 
-Hi, Meirin here. I've mentored on the Virtual Pipelines and Virtual Docker training after participating in the Awesome Bootcamp. I was a content developer and instructor for the HSF Machine Learning training. During 2021 I'll be HSF Training & Careers co-convenor. My work is to prepare ATLAS Open Data for use in education, including particle physics, data science and machine learning.
+Hi, Meirin here. I've mentored on the Virtual Pipelines and Virtual Docker training after participating in the Awesome Bootcamp. I was a content developer and instructor for the HSF Machine Learning training. During 2021 I'll be HSF Training & Careers co-convener. My work is to prepare ATLAS Open Data for use in education, including particle physics, data science and machine learning.

--- a/howto-profile.md
+++ b/howto-profile.md
@@ -78,4 +78,4 @@ If it doesn't, don't hesitate to ask us :)
 
 > My file contained some (syntax) errors and destroyed the community page
 
-Cool, that never happened before. But no worries, just write to the convenors, who apparently did a bad job at checking your file (if you can fix it quickly, a pull request would also be nice of course).
+Cool, that never happened before. But no worries, just write to the conveners, who apparently did a bad job at checking your file (if you can fix it quickly, a pull request would also be nice of course).


### PR DESCRIPTION
Indeed there were a few "convenor" left over here and there.

Note that I did not change the minutes as they are what they are. But nicer to have consistency among the website (active, as it were) pages.