### PR TITLE
Add pull request template for AI usage disclosure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,15 @@
 ## Description
 
-Please describe the purpose of this pull request.
+Please describe your pull request.
 
 ---
 
-## AI-assisted contribution
+### Please check if any of the following apply
 
-- [ ] I used AI tools while preparing this pull request.
+- [ ] AI was used in preparing this pull request.
 
 If checked, please briefly describe:
 
 - AI tool(s) used:
-- What was AI-assisted:
+- How AI was used:
 - What you manually reviewed or modified:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+
+Please describe the purpose of this pull request.
+
+---
+
+## AI-assisted contribution
+
+- [ ] I used AI tools while preparing this pull request.
+
+If checked, please briefly describe:
+
+- AI tool(s) used:
+- What was AI-assisted:
+- What you manually reviewed or modified:

--- a/_meetings/hsf-seminars.md
+++ b/_meetings/hsf-seminars.md
@@ -17,9 +17,13 @@ The schedule for past and future meetings is published in
 [Indico](https://indico.cern.ch/category/18810/).
 
 ## Organisers
+The seminar organisers are Claire Antel, Michel Jouvin and Nicole Skidmore.
 
-The [seminar organisers](mailto:claire.antel@cern.ch,michel.jouvin@ijclab.in2p3.fr,nicola.skidmore@cern.ch) are Claire Antel, Michel Jouvin and Nicole Skidmore, or
-you can contact the [HSF Steering Group](mailto:hsf-steering@googlegroups.com)
+For seminar enquiries, please contact the
+[HSF seminar conveners mailing list](mailto:hsf-seminar-conveners@googlegroups.com).
+
+You can also contact the
+[HSF Steering Group](mailto:hsf-steering@googlegroups.com)
 or any of our [activity area]({{ site.baseurl }}/what_are_activities.html)
 coordinators to suggest or volunteer any topics that you would like to see in
 future meetings.

--- a/howto-website.md
+++ b/howto-website.md
@@ -22,6 +22,19 @@ For adding information to this page or improving it, we follow the *[pull reques
 Just fork our HSF [website repository](https://github.com/HSF/hsf.github.io), edit the
 files you want to edit, push them to your fork, and open a pull request.
 
+### AI-assisted contributions
+
+AI-assisted contributions are welcome.
+
+Contributors remain fully responsible for everything they submit.
+
+If you use generative AI tools (such as ChatGPT, GitHub Copilot, or Claude) while preparing your contribution, please:
+
+- understand all generated content before submitting it;
+- carefully review and verify the correctness of AI-assisted changes;
+- remain fully responsible for everything included in your pull request;
+- disclose AI usage using the pull request template, where applicable.
+
 If you wish (and it is recommended) you can easily set up a local instance of the newsletter site in order to preview your submissions. See the [documentation](https://help.github.com/articles/using-jekyll-with-pages/)
 on installing and running Jekyll.
 The website uses the main branch of the [hsf.github.io](https://github.com/HSF/hsf.github.io) repository.


### PR DESCRIPTION
## Summary

This PR adds a pull request template with an optional AI usage disclosure section.

It implements the lightweight approach discussed in #1919 by allowing contributors to indicate whether AI tools were used while preparing the pull request and, if applicable, briefly describe how they were used and what was manually reviewed.

 PR intentionally focuses on the pull request template and does not introduce broader AI contribution policy documentation.
Related to #1919