### PR TITLE
Add CONTRIBUTING.md with contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+Thank you for your interest in contributing to the HSF website.
+
+Contributions of all sizes are welcome, including documentation improvements, typo fixes, bug fixes, and new content. For significant changes or new features, please open an issue first to discuss your proposal before starting work.
+
+## AI-assisted contributions
+
+AI-assisted contributions are welcome. If you use generative AI tools (such as ChatGPT, GitHub Copilot, or Claude) while preparing your contribution, please:
+
+- disclose the use of AI in your pull request when appropriate;
+- review and understand all AI-generated content before submitting it;
+- verify that the proposed changes are correct and appropriate for the project;
+- remain fully responsible for the content of your contribution.
+
+## Contributor etiquette
+
+To help keep reviews efficient and productive, please:
+
+- keep pull requests focused on a single logical change;
+- write clear commit messages and pull request descriptions;
+- be respectful and constructive in discussions;
+- assume good intentions and collaborate in a friendly manner.
+
+## Before opening a pull request
+
+Before submitting a pull request, please ensure that:
+
+- your changes have been reviewed by you;
+- your pull request description clearly explains the purpose of the changes;
+- your contribution does not introduce unintended modifications.
+
+## Additional guidance
+
+Practical information on editing the website, running a local preview, and contributing content is available in the website contribution guide:
+
+https://hepsoftwarefoundation.org/howto-website.html
+
+Thank you for helping improve the HSF website.


### PR DESCRIPTION
 #1951 

## Summary

This PR adds a `CONTRIBUTING.md` file that provides guidance for contributors.

### Changes

- Added contribution workflow
- Added contributor etiquette
- Added guidance for AI-assisted contributions
- Linked to the existing website contribution guide

### Highlights

- Welcome new contributors
- Encourage discussion before significant changes
- Add guidance for AI-assisted contributions
- Outline contributor etiquette and pull request expectations
- Link to the existing website contribution guide

Related to  #1951
<img width="1512" height="982" alt="Screenshot 2026-08-01 at 2 10 43 PM" src="https://github.com/user-attachments/assets/c2c8c7f5-6b7b-4b82-acc9-cfd2eb633954" />
